### PR TITLE
Add clang extra tools

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -8,14 +8,18 @@ package:
   version: {{ version }}
 
 source:
-  url: http://releases.llvm.org/{{ version }}/cfe-{{ version }}.src.tar.xz
-  sha256: {{ sha256 }}
-  patches:
-    - patches/0001-Find-conda-gcc-installation.patch
-    - patches/0002-Fix-sysroot-detection-for-linux.patch
-    - patches/0002-clang-add-conda-specific-env-var-CONDA_BUILD_SYSROOT.patch
-    - patches/0003-clang-Fix-normalizeProgramName-s-handling-of-dots-ou.patch
-    - patches/0001-Set-VERSION-in-osx-as-well.patch
+  - url: http://releases.llvm.org/{{ version }}/cfe-{{ version }}.src.tar.xz
+    sha256: {{ sha256 }}
+    patches:
+      - patches/0001-Find-conda-gcc-installation.patch
+      - patches/0002-Fix-sysroot-detection-for-linux.patch
+      - patches/0002-clang-add-conda-specific-env-var-CONDA_BUILD_SYSROOT.patch
+      - patches/0003-clang-Fix-normalizeProgramName-s-handling-of-dots-ou.patch
+      - patches/0001-Set-VERSION-in-osx-as-well.patch
+    folder: .
+  - url: http://releases.llvm.org/{{ version }}/clang-tools-extra-{{ version }}.src.tar.xz
+    sha256: ea1c86ce352992d7b6f6649bc622f6a2707b9f8b7153e9f9181a35c76aa3ac10
+    folder: tools/extra
 
 build:
   number: {{ build_number }}
@@ -181,6 +185,7 @@ outputs:
     test:
       commands:
         - clang-check --version
+        - clang-tidy --version
 
   - name: python-clang
     build:


### PR DESCRIPTION
Low-effort addition of clang tools extra:
https://clang.llvm.org/extra/index.html

Extra tools are built as part of clangdev and included
in the clang-tools package.  This grows the size of the
clang-tools package to ~110MB and I'm sure will make the buildtime
quite a bit longer.

fixes #10

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [X] Used a [fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [X] Bumped the build number (if the version is unchanged)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [X] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
