### PR TITLE
Follow sysroot changes

### DIFF
--- a/.azure-pipelines/azure-pipelines-linux.yml
+++ b/.azure-pipelines/azure-pipelines-linux.yml
@@ -8,22 +8,35 @@ jobs:
     vmImage: ubuntu-16.04
   strategy:
     matrix:
-      linux_clang_variantcling_v0.6:
-        CONFIG: linux_clang_variantcling_v0.6
+      linux_64_clang_variantcling_v0.6:
+        CONFIG: linux_64_clang_variantcling_v0.6
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: condaforge/linux-anvil-comp7
-      linux_clang_variantdefault:
-        CONFIG: linux_clang_variantdefault
+      linux_64_clang_variantdefault:
+        CONFIG: linux_64_clang_variantdefault
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: condaforge/linux-anvil-comp7
-      linux_clang_variantroot_20200518:
-        CONFIG: linux_clang_variantroot_20200518
+      linux_64_clang_variantroot_20190625:
+        CONFIG: linux_64_clang_variantroot_20190625
+        UPLOAD_PACKAGES: 'True'
+        DOCKER_IMAGE: condaforge/linux-anvil-comp7
+      linux_64_clang_variantroot_20191220:
+        CONFIG: linux_64_clang_variantroot_20191220
+        UPLOAD_PACKAGES: 'True'
+        DOCKER_IMAGE: condaforge/linux-anvil-comp7
+      linux_64_clang_variantroot_20200518:
+        CONFIG: linux_64_clang_variantroot_20200518
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: condaforge/linux-anvil-comp7
     maxParallel: 8
   timeoutInMinutes: 360
 
   steps:
+  - script: |
+         rm -rf /opt/ghc
+         df -h
+    displayName: Manage disk space
+
   # configure qemu binfmt-misc running.  This allows us to run docker containers
   # embedded qemu-static
   - script: |
@@ -35,6 +48,7 @@ jobs:
   - script: |
         export CI=azure
         export GIT_BRANCH=$BUILD_SOURCEBRANCHNAME
+        export FEEDSTOCK_NAME=$(basename ${BUILD_REPOSITORY_NAME})
         .scripts/run_docker_build.sh
     displayName: Run docker build
     env:

--- a/.azure-pipelines/azure-pipelines-osx.yml
+++ b/.azure-pipelines/azure-pipelines-osx.yml
@@ -8,14 +8,20 @@ jobs:
     vmImage: macOS-10.14
   strategy:
     matrix:
-      osx_clang_variantcling_v0.6:
-        CONFIG: osx_clang_variantcling_v0.6
+      osx_64_clang_variantcling_v0.6:
+        CONFIG: osx_64_clang_variantcling_v0.6
         UPLOAD_PACKAGES: 'True'
-      osx_clang_variantdefault:
-        CONFIG: osx_clang_variantdefault
+      osx_64_clang_variantdefault:
+        CONFIG: osx_64_clang_variantdefault
         UPLOAD_PACKAGES: 'True'
-      osx_clang_variantroot_20200518:
-        CONFIG: osx_clang_variantroot_20200518
+      osx_64_clang_variantroot_20190625:
+        CONFIG: osx_64_clang_variantroot_20190625
+        UPLOAD_PACKAGES: 'True'
+      osx_64_clang_variantroot_20191220:
+        CONFIG: osx_64_clang_variantroot_20191220
+        UPLOAD_PACKAGES: 'True'
+      osx_64_clang_variantroot_20200518:
+        CONFIG: osx_64_clang_variantroot_20200518
         UPLOAD_PACKAGES: 'True'
     maxParallel: 8
   timeoutInMinutes: 360
@@ -26,6 +32,7 @@ jobs:
       export CI=azure
       export OSX_FORCE_SDK_DOWNLOAD="1"
       export GIT_BRANCH=$BUILD_SOURCEBRANCHNAME
+      export FEEDSTOCK_NAME=$(basename ${BUILD_REPOSITORY_NAME})
       ./.scripts/run_osx_build.sh
     displayName: Run OSX build
     env:

--- a/.azure-pipelines/azure-pipelines-win.yml
+++ b/.azure-pipelines/azure-pipelines-win.yml
@@ -8,14 +8,20 @@ jobs:
     vmImage: vs2017-win2016
   strategy:
     matrix:
-      win_clang_variantcling_v0.6:
-        CONFIG: win_clang_variantcling_v0.6
+      win_64_clang_variantcling_v0.6:
+        CONFIG: win_64_clang_variantcling_v0.6
         UPLOAD_PACKAGES: 'True'
-      win_clang_variantdefault:
-        CONFIG: win_clang_variantdefault
+      win_64_clang_variantdefault:
+        CONFIG: win_64_clang_variantdefault
         UPLOAD_PACKAGES: 'True'
-      win_clang_variantroot_20200518:
-        CONFIG: win_clang_variantroot_20200518
+      win_64_clang_variantroot_20190625:
+        CONFIG: win_64_clang_variantroot_20190625
+        UPLOAD_PACKAGES: 'True'
+      win_64_clang_variantroot_20191220:
+        CONFIG: win_64_clang_variantroot_20191220
+        UPLOAD_PACKAGES: 'True'
+      win_64_clang_variantroot_20200518:
+        CONFIG: win_64_clang_variantroot_20200518
         UPLOAD_PACKAGES: 'True'
     maxParallel: 4
   timeoutInMinutes: 360
@@ -99,14 +105,16 @@ jobs:
         PYTHONUNBUFFERED: 1
       condition: not(contains(variables['CONFIG'], 'vs2008'))
     - script: |
+        set "FEEDSTOCK_NAME=%BUILD_REPOSITORY_NAME:*/=%"
         call activate base
-        validate_recipe_outputs "clangdev-feedstock"
+        validate_recipe_outputs "%FEEDSTOCK_NAME%"
       displayName: Validate Recipe Outputs
 
     - script: |
         set "GIT_BRANCH=%BUILD_SOURCEBRANCHNAME%"
+        set "FEEDSTOCK_NAME=%BUILD_REPOSITORY_NAME:*/=%"
         call activate base
-        upload_package --validate --feedstock-name="clangdev-feedstock" .\ ".\recipe" .ci_support\%CONFIG%.yaml
+        upload_package --validate --feedstock-name="%FEEDSTOCK_NAME%" .\ ".\recipe" .ci_support\%CONFIG%.yaml
       displayName: Upload package
       env:
         BINSTAR_TOKEN: $(BINSTAR_TOKEN)

--- a/.ci_support/linux_64_clang_variantcling_v0.6.yaml
+++ b/.ci_support/linux_64_clang_variantcling_v0.6.yaml
@@ -3,10 +3,12 @@ channel_sources:
 channel_targets:
 - conda-forge main
 clang_variant:
-- root_20191220
+- cling_v0.6
 cxx_compiler:
 - gxx
 cxx_compiler_version:
 - '7'
 docker_image:
 - condaforge/linux-anvil-comp7
+target_platform:
+- linux-64

--- a/.ci_support/linux_64_clang_variantdefault.yaml
+++ b/.ci_support/linux_64_clang_variantdefault.yaml
@@ -5,6 +5,10 @@ channel_targets:
 clang_variant:
 - default
 cxx_compiler:
-- vs2017
-vc:
-- '14'
+- gxx
+cxx_compiler_version:
+- '7'
+docker_image:
+- condaforge/linux-anvil-comp7
+target_platform:
+- linux-64

--- a/.ci_support/linux_64_clang_variantroot_20190625.yaml
+++ b/.ci_support/linux_64_clang_variantroot_20190625.yaml
@@ -3,10 +3,12 @@ channel_sources:
 channel_targets:
 - conda-forge main
 clang_variant:
-- cling_v0.6
+- root_20190625
 cxx_compiler:
 - gxx
 cxx_compiler_version:
 - '7'
 docker_image:
 - condaforge/linux-anvil-comp7
+target_platform:
+- linux-64

--- a/.ci_support/linux_64_clang_variantroot_20191220.yaml
+++ b/.ci_support/linux_64_clang_variantroot_20191220.yaml
@@ -5,12 +5,10 @@ channel_targets:
 clang_variant:
 - root_20191220
 cxx_compiler:
-- vs2015
-pin_run_as_build:
-  vc:
-    max_pin: x
-vc:
-- '14'
-zip_keys:
-- - vc
-  - cxx_compiler
+- gxx
+cxx_compiler_version:
+- '7'
+docker_image:
+- condaforge/linux-anvil-comp7
+target_platform:
+- linux-64

--- a/.ci_support/linux_64_clang_variantroot_20200518.yaml
+++ b/.ci_support/linux_64_clang_variantroot_20200518.yaml
@@ -5,6 +5,10 @@ channel_targets:
 clang_variant:
 - root_20200518
 cxx_compiler:
-- vs2017
-vc:
-- '14'
+- gxx
+cxx_compiler_version:
+- '7'
+docker_image:
+- condaforge/linux-anvil-comp7
+target_platform:
+- linux-64

--- a/.ci_support/osx_64_clang_variantcling_v0.6.yaml
+++ b/.ci_support/osx_64_clang_variantcling_v0.6.yaml
@@ -1,0 +1,23 @@
+MACOSX_DEPLOYMENT_TARGET:
+- '10.9'
+channel_sources:
+- conda-forge,defaults
+channel_targets:
+- conda-forge main
+clang_variant:
+- cling_v0.6
+cxx_compiler:
+- clangxx
+cxx_compiler_version:
+- '10'
+libxml2:
+- '2.9'
+macos_machine:
+- x86_64-apple-darwin13.4.0
+macos_min_version:
+- '10.9'
+pin_run_as_build:
+  libxml2:
+    max_pin: x.x
+target_platform:
+- osx-64

--- a/.ci_support/osx_64_clang_variantdefault.yaml
+++ b/.ci_support/osx_64_clang_variantdefault.yaml
@@ -5,11 +5,11 @@ channel_sources:
 channel_targets:
 - conda-forge main
 clang_variant:
-- root_20191220
+- default
 cxx_compiler:
 - clangxx
 cxx_compiler_version:
-- '9'
+- '10'
 libxml2:
 - '2.9'
 macos_machine:
@@ -19,7 +19,5 @@ macos_min_version:
 pin_run_as_build:
   libxml2:
     max_pin: x.x
-  zlib:
-    max_pin: x.x
-zlib:
-- '1.2'
+target_platform:
+- osx-64

--- a/.ci_support/osx_64_clang_variantroot_20190625.yaml
+++ b/.ci_support/osx_64_clang_variantroot_20190625.yaml
@@ -5,11 +5,11 @@ channel_sources:
 channel_targets:
 - conda-forge main
 clang_variant:
-- default
+- root_20190625
 cxx_compiler:
 - clangxx
 cxx_compiler_version:
-- '9'
+- '10'
 libxml2:
 - '2.9'
 macos_machine:
@@ -19,3 +19,5 @@ macos_min_version:
 pin_run_as_build:
   libxml2:
     max_pin: x.x
+target_platform:
+- osx-64

--- a/.ci_support/osx_64_clang_variantroot_20191220.yaml
+++ b/.ci_support/osx_64_clang_variantroot_20191220.yaml
@@ -5,11 +5,11 @@ channel_sources:
 channel_targets:
 - conda-forge main
 clang_variant:
-- root_20200518
+- root_20191220
 cxx_compiler:
 - clangxx
 cxx_compiler_version:
-- '9'
+- '10'
 libxml2:
 - '2.9'
 macos_machine:
@@ -19,3 +19,5 @@ macos_min_version:
 pin_run_as_build:
   libxml2:
     max_pin: x.x
+target_platform:
+- osx-64

--- a/.ci_support/osx_64_clang_variantroot_20200518.yaml
+++ b/.ci_support/osx_64_clang_variantroot_20200518.yaml
@@ -5,11 +5,11 @@ channel_sources:
 channel_targets:
 - conda-forge main
 clang_variant:
-- cling_v0.6
+- root_20200518
 cxx_compiler:
 - clangxx
 cxx_compiler_version:
-- '9'
+- '10'
 libxml2:
 - '2.9'
 macos_machine:
@@ -19,3 +19,5 @@ macos_min_version:
 pin_run_as_build:
   libxml2:
     max_pin: x.x
+target_platform:
+- osx-64

--- a/.ci_support/win_64_clang_variantcling_v0.6.yaml
+++ b/.ci_support/win_64_clang_variantcling_v0.6.yaml
@@ -5,12 +5,8 @@ channel_targets:
 clang_variant:
 - cling_v0.6
 cxx_compiler:
-- vs2015
-pin_run_as_build:
-  vc:
-    max_pin: x
+- vs2017
+target_platform:
+- win-64
 vc:
 - '14'
-zip_keys:
-- - vc
-  - cxx_compiler

--- a/.ci_support/win_64_clang_variantdefault.yaml
+++ b/.ci_support/win_64_clang_variantdefault.yaml
@@ -5,8 +5,8 @@ channel_targets:
 clang_variant:
 - default
 cxx_compiler:
-- gxx
-cxx_compiler_version:
-- '7'
-docker_image:
-- condaforge/linux-anvil-comp7
+- vs2017
+target_platform:
+- win-64
+vc:
+- '14'

--- a/.ci_support/win_64_clang_variantroot_20190625.yaml
+++ b/.ci_support/win_64_clang_variantroot_20190625.yaml
@@ -3,10 +3,10 @@ channel_sources:
 channel_targets:
 - conda-forge main
 clang_variant:
-- root_20200518
+- root_20190625
 cxx_compiler:
-- gxx
-cxx_compiler_version:
-- '7'
-docker_image:
-- condaforge/linux-anvil-comp7
+- vs2017
+target_platform:
+- win-64
+vc:
+- '14'

--- a/.ci_support/win_64_clang_variantroot_20191220.yaml
+++ b/.ci_support/win_64_clang_variantroot_20191220.yaml
@@ -3,14 +3,10 @@ channel_sources:
 channel_targets:
 - conda-forge main
 clang_variant:
-- default
+- root_20191220
 cxx_compiler:
-- vs2015
-pin_run_as_build:
-  vc:
-    max_pin: x
+- vs2017
+target_platform:
+- win-64
 vc:
 - '14'
-zip_keys:
-- - vc
-  - cxx_compiler

--- a/.ci_support/win_64_clang_variantroot_20200518.yaml
+++ b/.ci_support/win_64_clang_variantroot_20200518.yaml
@@ -3,8 +3,10 @@ channel_sources:
 channel_targets:
 - conda-forge main
 clang_variant:
-- cling_v0.6
+- root_20200518
 cxx_compiler:
 - vs2017
+target_platform:
+- win-64
 vc:
 - '14'

--- a/.scripts/build_steps.sh
+++ b/.scripts/build_steps.sh
@@ -30,11 +30,12 @@ source run_conda_forge_build_setup
 make_build_number "${FEEDSTOCK_ROOT}" "${RECIPE_ROOT}" "${CONFIG_FILE}"
 
 conda build "${RECIPE_ROOT}" -m "${CI_SUPPORT}/${CONFIG}.yaml" \
+    --suppress-variables \
     --clobber-file "${CI_SUPPORT}/clobber_${CONFIG}.yaml"
-validate_recipe_outputs "clangdev-feedstock"
+validate_recipe_outputs "${FEEDSTOCK_NAME}"
 
 if [[ "${UPLOAD_PACKAGES}" != "False" ]]; then
-    upload_package --validate --feedstock-name="clangdev-feedstock" "${FEEDSTOCK_ROOT}" "${RECIPE_ROOT}" "${CONFIG_FILE}"
+    upload_package --validate --feedstock-name="${FEEDSTOCK_NAME}"  "${FEEDSTOCK_ROOT}" "${RECIPE_ROOT}" "${CONFIG_FILE}"
 fi
 
 touch "${FEEDSTOCK_ROOT}/build_artifacts/conda-forge-build-done-${CONFIG}"

--- a/.scripts/run_docker_build.sh
+++ b/.scripts/run_docker_build.sh
@@ -13,6 +13,10 @@ PROVIDER_DIR="$(basename $THISDIR)"
 FEEDSTOCK_ROOT=$(cd "$(dirname "$0")/.."; pwd;)
 RECIPE_ROOT="${FEEDSTOCK_ROOT}/recipe"
 
+if [ -z ${FEEDSTOCK_NAME} ]; then
+    export FEEDSTOCK_NAME=$(basename ${FEEDSTOCK_ROOT})
+fi
+
 docker info
 
 # In order for the conda-build process in the container to write to the mounted
@@ -63,12 +67,14 @@ docker run ${DOCKER_RUN_ARGS} \
            -v "${RECIPE_ROOT}":/home/conda/recipe_root:rw,z \
            -v "${FEEDSTOCK_ROOT}":/home/conda/feedstock_root:rw,z \
            -e CONFIG \
-           -e BINSTAR_TOKEN \
            -e HOST_USER_ID \
            -e UPLOAD_PACKAGES \
            -e GIT_BRANCH \
            -e UPLOAD_ON_BRANCH \
            -e CI \
+           -e FEEDSTOCK_NAME \
+           -e CPU_COUNT \
+           -e BINSTAR_TOKEN \
            -e FEEDSTOCK_TOKEN \
            -e STAGING_BINSTAR_TOKEN \
            $DOCKER_IMAGE \

--- a/.scripts/run_osx_build.sh
+++ b/.scripts/run_osx_build.sh
@@ -47,10 +47,10 @@ set -e
 
 echo -e "\n\nMaking the build clobber file and running the build."
 make_build_number ./ ./recipe ./.ci_support/${CONFIG}.yaml
-conda build ./recipe -m ./.ci_support/${CONFIG}.yaml --clobber-file ./.ci_support/clobber_${CONFIG}.yaml
-validate_recipe_outputs "clangdev-feedstock"
+conda build ./recipe -m ./.ci_support/${CONFIG}.yaml --suppress-variables --clobber-file ./.ci_support/clobber_${CONFIG}.yaml
+validate_recipe_outputs "${FEEDSTOCK_NAME}"
 
 if [[ "${UPLOAD_PACKAGES}" != "False" ]]; then
   echo -e "\n\nUploading the packages."
-  upload_package --validate --feedstock-name="clangdev-feedstock" ./ ./recipe ./.ci_support/${CONFIG}.yaml
+  upload_package --validate --feedstock-name="${FEEDSTOCK_NAME}" ./ ./recipe ./.ci_support/${CONFIG}.yaml
 fi

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,5 +1,5 @@
 BSD 3-clause license
-Copyright (c) 2015-2019, conda-forge
+Copyright (c) 2015-2020, conda-forge contributors
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Home: http://llvm.org/
 
 Package license: NCSA
 
-Feedstock license: BSD 3-Clause
+Feedstock license: BSD-3-Clause
 
 Summary: Development headers and libraries for Clang
 
@@ -29,78 +29,114 @@ Current build status
         <table>
           <thead><tr><th>Variant</th><th>Status</th></tr></thead>
           <tbody><tr>
-              <td>linux_clang_variantcling_v0.6</td>
+              <td>linux_64_clang_variantcling_v0.6</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=153&branchName=master">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/clangdev-feedstock?branchName=master&jobName=linux&configuration=linux_clang_variantcling_v0.6" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/clangdev-feedstock?branchName=master&jobName=linux&configuration=linux_64_clang_variantcling_v0.6" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>linux_clang_variantdefault</td>
+              <td>linux_64_clang_variantdefault</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=153&branchName=master">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/clangdev-feedstock?branchName=master&jobName=linux&configuration=linux_clang_variantdefault" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/clangdev-feedstock?branchName=master&jobName=linux&configuration=linux_64_clang_variantdefault" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>linux_clang_variantroot_20200518</td>
+              <td>linux_64_clang_variantroot_20190625</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=153&branchName=master">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/clangdev-feedstock?branchName=master&jobName=linux&configuration=linux_clang_variantroot_20200518" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/clangdev-feedstock?branchName=master&jobName=linux&configuration=linux_64_clang_variantroot_20190625" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>osx_clang_variantcling_v0.6</td>
+              <td>linux_64_clang_variantroot_20191220</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=153&branchName=master">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/clangdev-feedstock?branchName=master&jobName=osx&configuration=osx_clang_variantcling_v0.6" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/clangdev-feedstock?branchName=master&jobName=linux&configuration=linux_64_clang_variantroot_20191220" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>osx_clang_variantdefault</td>
+              <td>linux_64_clang_variantroot_20200518</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=153&branchName=master">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/clangdev-feedstock?branchName=master&jobName=osx&configuration=osx_clang_variantdefault" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/clangdev-feedstock?branchName=master&jobName=linux&configuration=linux_64_clang_variantroot_20200518" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>osx_clang_variantroot_20200518</td>
+              <td>osx_64_clang_variantcling_v0.6</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=153&branchName=master">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/clangdev-feedstock?branchName=master&jobName=osx&configuration=osx_clang_variantroot_20200518" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/clangdev-feedstock?branchName=master&jobName=osx&configuration=osx_64_clang_variantcling_v0.6" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>win_clang_variantcling_v0.6</td>
+              <td>osx_64_clang_variantdefault</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=153&branchName=master">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/clangdev-feedstock?branchName=master&jobName=win&configuration=win_clang_variantcling_v0.6" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/clangdev-feedstock?branchName=master&jobName=osx&configuration=osx_64_clang_variantdefault" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>win_clang_variantdefault</td>
+              <td>osx_64_clang_variantroot_20190625</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=153&branchName=master">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/clangdev-feedstock?branchName=master&jobName=win&configuration=win_clang_variantdefault" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/clangdev-feedstock?branchName=master&jobName=osx&configuration=osx_64_clang_variantroot_20190625" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>win_clang_variantroot_20200518</td>
+              <td>osx_64_clang_variantroot_20191220</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=153&branchName=master">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/clangdev-feedstock?branchName=master&jobName=win&configuration=win_clang_variantroot_20200518" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/clangdev-feedstock?branchName=master&jobName=osx&configuration=osx_64_clang_variantroot_20191220" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>osx_64_clang_variantroot_20200518</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=153&branchName=master">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/clangdev-feedstock?branchName=master&jobName=osx&configuration=osx_64_clang_variantroot_20200518" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>win_64_clang_variantcling_v0.6</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=153&branchName=master">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/clangdev-feedstock?branchName=master&jobName=win&configuration=win_64_clang_variantcling_v0.6" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>win_64_clang_variantdefault</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=153&branchName=master">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/clangdev-feedstock?branchName=master&jobName=win&configuration=win_64_clang_variantdefault" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>win_64_clang_variantroot_20190625</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=153&branchName=master">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/clangdev-feedstock?branchName=master&jobName=win&configuration=win_64_clang_variantroot_20190625" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>win_64_clang_variantroot_20191220</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=153&branchName=master">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/clangdev-feedstock?branchName=master&jobName=win&configuration=win_64_clang_variantroot_20191220" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>win_64_clang_variantroot_20200518</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=153&branchName=master">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/clangdev-feedstock?branchName=master&jobName=win&configuration=win_64_clang_variantroot_20200518" alt="variant">
                 </a>
               </td>
             </tr>
           </tbody>
         </table>
       </details>
-    </td>
-  </tr>
-  <tr>
-    <td>Linux_ppc64le</td>
-    <td>
-      <img src="https://img.shields.io/badge/ppc64le-disabled-lightgrey.svg" alt="ppc64le disabled">
     </td>
   </tr>
 </table>

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -4,5 +4,5 @@
 
 jobs:
   - template: ./.azure-pipelines/azure-pipelines-linux.yml
-  - template: ./.azure-pipelines/azure-pipelines-osx.yml
   - template: ./.azure-pipelines/azure-pipelines-win.yml
+  - template: ./.azure-pipelines/azure-pipelines-osx.yml

--- a/recipe/build_clangdev.sh
+++ b/recipe/build_clangdev.sh
@@ -15,10 +15,10 @@ if [[ "$(uname)" == "Darwin" ]]; then
 fi
 
 if [[ "$(uname)" == "Linux" && "$cxx_compiler" == "gxx" ]]; then
-    sed -i.bak -e 's@SYSROOT_PATH_TO_BE_REPLACED_WITH_SED@'"${PREFIX}/${HOST}/sysroot"'@g' \
+    sed -i.bak -e 's@SYSROOT_PATH_TO_BE_REPLACED_WITH_SED@'"${CONDA_BUILD_SYSROOT}"'@g' \
         lib/Driver/ToolChains/Linux_sysroot.cc && rm $_.bak
 
-    sed -i.bak -e 's@AddPath("/usr/local/include", System, false);@AddPath("'"${PREFIX}/${HOST}/sysroot/usr/include"'", System, false);@g' \
+    sed -i.bak -e 's@AddPath("/usr/local/include", System, false);@AddPath("'"${CONDA_BUILD_SYSROOT}"'", System, false);@g' \
         lib/Frontend/InitHeaderSearch.cpp && rm $_.bak
 fi
 

--- a/recipe/build_clangdev.sh
+++ b/recipe/build_clangdev.sh
@@ -15,10 +15,12 @@ if [[ "$(uname)" == "Darwin" ]]; then
 fi
 
 if [[ "$(uname)" == "Linux" && "$cxx_compiler" == "gxx" ]]; then
-    sed -i.bak -e 's@SYSROOT_PATH_TO_BE_REPLACED_WITH_SED@'"${CONDA_BUILD_SYSROOT}"'@g' \
+    INSTALL_SYSROOT=$(python -c "import os; rel = os.path.relpath('$CONDA_BUILD_SYSROOT', '$CONDA_PREFIX'); assert not rel.startswith('.'); print(os.path.join('$PREFIX', rel))")
+    echo "INSTALL_SYSROOT is ${INSTALL_SYSROOT}"
+    sed -i.bak -e 's@SYSROOT_PATH_TO_BE_REPLACED_WITH_SED@'"${INSTALL_SYSROOT}"'@g' \
         lib/Driver/ToolChains/Linux_sysroot.cc && rm $_.bak
 
-    sed -i.bak -e 's@AddPath("/usr/local/include", System, false);@AddPath("'"${CONDA_BUILD_SYSROOT}"'", System, false);@g' \
+    sed -i.bak -e 's@AddPath("/usr/local/include", System, false);@AddPath("'"${INSTALL_SYSROOT}"'", System, false);@g' \
         lib/Frontend/InitHeaderSearch.cpp && rm $_.bak
 fi
 

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,4 +1,6 @@
 clang_variant:
   - default
   - cling_v0.6       # tag is cling-v0.6
+  - root_20190625    # tag is for 6.18.04
+  - root_20191220    # tag is for 6.20.00
   - root_20200518    # tag is for 6.22.00

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -18,6 +18,14 @@ source:
 {% elif clang_variant.startswith("cling") %}
   git_url: http://root.cern.ch/git/clang.git
   git_rev: {{ clang_variant|replace('cling_', 'cling-') }}
+{% elif clang_variant.startswith("root_20190625") %}
+  git_url: https://github.com/root-project/root.git
+  git_rev: 6b8f54808eb13103e87cae19c642aec474270422
+  folder: root-source
+{% elif clang_variant.startswith("root_20191220") %}
+  git_url: https://github.com/root-project/root.git
+  git_rev: fde5aa88ea02dfcd9fe20c346ece1c2b6aabfe6d
+  folder: root-source
 {% elif clang_variant.startswith("root") %}
   git_url: https://github.com/root-project/root.git
   git_rev: c100d61bd56d05058843da021cf1f740166aad38

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,7 +1,7 @@
 {% set version = "5.0.0" %}
 {% set sha256 = "019f23c2192df793ac746595e94a403908749f8e0c484b403476d2611dd20970" %}
 
-{% set build_number = "1007" %}
+{% set build_number = "1008" %}
 
 {% if not clang_variant %}
 {% set clang_variant = "default" %}


### PR DESCRIPTION
The sysroot has been moved from `x86_64-conda_cos6-linux-gnu` to `x86_64-conda-linux-gnu` which causes the use of `$HOST` here to be wrong. This breaks `root` and `cling` as they need to find use the headers at runtime. I was a little surprised nobody had reported issues but it turns out the `CONDA_BUILD_SYSROOT` environment variable is normally and hides the problem for most people.

@SylvainCorlay In case you come across the error below, this should fix it (after it's merged and cling is rebuilt).
```
In file included from input_line_1:1:
In file included from /home/cburr/miniconda3/envs/test-cling/bin/../lib/gcc/x86_64-conda-linux-gnu/7.5.0/../../../../x86_64-conda-linux-gnu/include/c++/7.5.0/new:39:
In file included from /home/cburr/miniconda3/envs/test-cling/bin/../lib/gcc/x86_64-conda-linux-gnu/7.5.0/../../../../x86_64-conda-linux-gnu/include/c++/7.5.0/x86_64-conda-linux-gnu/bits/c++config.h:533:
/home/cburr/miniconda3/envs/test-cling/bin/../lib/gcc/x86_64-conda-linux-gnu/7.5.0/../../../../x86_64-conda-linux-gnu/include/c++/7.5.0/x86_64-conda-linux-gnu/bits/os_defines.h:39:10: fatal error: 'features.h' file not found
#include <features.h>
         ^~~~~~~~~~~~
Warning in cling::IncrementalParser::CheckABICompatibility():
  Possible C++ standard library mismatch, compiled with __GLIBCXX__ '20180125'
  Extraction of runtime standard library version was: '20191114'

****************** CLING ******************
* Type C++ code and press enter to run it *
*             Type .q to exit             *
*******************************************
[cling]$ .q
```

Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
