### PR TITLE
Disable -Werror,-Wundef-prefix=TARGET_OS as they are not yet defined in the 10.9 SDK used for osx-64

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -17,6 +17,7 @@ source:
       - patches/0001-Set-VERSION-in-osx-as-well.patch
       - patches/cross-compile.diff
       # Disable -Werror,-Wundef-prefix=TARGET_OS as they are not yet defined in the 10.9 SDK used for osx-64
+      # Only enable it for TARGET_OS_OSX.
       - patches/disable-wundef-prefix.patch  # [osx and x86_64]
       #- patches/amd-roc-2.7.0.diff   # [variant != "hcc"]
       #- patches/amd-roc-hcc-2.7.0.diff  # [variant == "hcc"]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set version = "11.0.0" %}
 {% set major_version = version.split(".")[0] %}
-{% set build_number = 1 %}
+{% set build_number = 2 %}
 
 package:
   name: clang_packages
@@ -16,6 +16,8 @@ source:
       - patches/0003-clang-Fix-normalizeProgramName-s-handling-of-dots-ou.patch
       - patches/0001-Set-VERSION-in-osx-as-well.patch
       - patches/cross-compile.diff
+      # Disable -Werror,-Wundef-prefix=TARGET_OS as they are not yet defined in the 10.9 SDK used for osx-64
+      - patches/disable-wundef-prefix.patch  # [osx and x86_64]
       #- patches/amd-roc-2.7.0.diff   # [variant != "hcc"]
       #- patches/amd-roc-hcc-2.7.0.diff  # [variant == "hcc"]
     folder: .

--- a/recipe/patches/disable-wundef-prefix.patch
+++ b/recipe/patches/disable-wundef-prefix.patch
@@ -1,13 +1,11 @@
---- lib/Driver/ToolChains/Darwin.cpp.orig	2020-11-17 11:41:09.000000000 +0100
-+++ lib/Driver/ToolChains/Darwin.cpp	2020-11-17 11:41:20.000000000 +0100
-@@ -959,10 +959,6 @@
-     : Darwin(D, Triple, Args) {}
+--- lib/Driver/ToolChains/Darwin.cpp.orig	2020-11-17 21:12:24.000000000 +0100
++++ lib/Driver/ToolChains/Darwin.cpp	2020-11-17 21:12:37.000000000 +0100
+@@ -960,7 +960,7 @@
  
  void DarwinClang::addClangWarningOptions(ArgStringList &CC1Args) const {
--  // Always error about undefined 'TARGET_OS_*' macros.
+   // Always error about undefined 'TARGET_OS_*' macros.
 -  CC1Args.push_back("-Wundef-prefix=TARGET_OS_");
--  CC1Args.push_back("-Werror=undef-prefix");
--
++  CC1Args.push_back("-Wundef-prefix=TARGET_OS_OSX");
+   CC1Args.push_back("-Werror=undef-prefix");
+ 
    // For modern targets, promote certain warnings to errors.
-   if (isTargetWatchOSBased() || getTriple().isArch64Bit()) {
-     // Always enable -Wdeprecated-objc-isa-usage and promote it

--- a/recipe/patches/disable-wundef-prefix.patch
+++ b/recipe/patches/disable-wundef-prefix.patch
@@ -1,0 +1,13 @@
+--- lib/Driver/ToolChains/Darwin.cpp.orig	2020-11-17 11:41:09.000000000 +0100
++++ lib/Driver/ToolChains/Darwin.cpp	2020-11-17 11:41:20.000000000 +0100
+@@ -959,10 +959,6 @@
+     : Darwin(D, Triple, Args) {}
+ 
+ void DarwinClang::addClangWarningOptions(ArgStringList &CC1Args) const {
+-  // Always error about undefined 'TARGET_OS_*' macros.
+-  CC1Args.push_back("-Wundef-prefix=TARGET_OS_");
+-  CC1Args.push_back("-Werror=undef-prefix");
+-
+   // For modern targets, promote certain warnings to errors.
+   if (isTargetWatchOSBased() || getTriple().isArch64Bit()) {
+     // Always enable -Wdeprecated-objc-isa-usage and promote it


### PR DESCRIPTION
Fixes #116 

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
