### PR TITLE
Add the new Conda sysroot triple to default GCC prefixes

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set version = "8.0.1" %}
 {% set major_version = version.split(".")[0] %}
-{% set build_number = 2 %}
+{% set build_number = 3 %}
 
 package:
   name: clang_packages

--- a/recipe/patches/0001-Find-conda-gcc-installation.patch
+++ b/recipe/patches/0001-Find-conda-gcc-installation.patch
@@ -16,7 +16,7 @@ index 2ad45097..1ad905a4 100644
    static const char *const AArch64Triples[] = {
        "aarch64-none-linux-gnu", "aarch64-linux-gnu", "aarch64-redhat-linux",
 -      "aarch64-suse-linux", "aarch64-linux-android"};
-+      "aarch64-suse-linux", "aarch64-linux-android", "aarch64-conda_cos7-linux-gnu"};
++      "aarch64-suse-linux", "aarch64-linux-android", "aarch64-conda_cos7-linux-gnu", "aarch64-conda-linux-gnu"};
    static const char *const AArch64beLibDirs[] = {"/lib"};
    static const char *const AArch64beTriples[] = {"aarch64_be-none-linux-gnu",
                                                   "aarch64_be-linux-gnu"};
@@ -26,7 +26,7 @@ index 2ad45097..1ad905a4 100644
        "x86_64-slackware-linux", "x86_64-unknown-linux",
 -      "x86_64-amazon-linux",    "x86_64-linux-android"};
 +      "x86_64-amazon-linux",    "x86_64-linux-android",
-+      "x86_64-conda_cos6-linux-gnu", "x86_64-conda_cos7-linux-gnu"};
++      "x86_64-conda_cos6-linux-gnu", "x86_64-conda_cos7-linux-gnu", "x86_64-conda-linux-gnu"};
    static const char *const X32LibDirs[] = {"/libx32"};
    static const char *const X86LibDirs[] = {"/lib32", "/lib"};
    static const char *const X86Triples[] = {
@@ -35,7 +35,7 @@ index 2ad45097..1ad905a4 100644
    static const char *const PPC64LETriples[] = {
        "powerpc64le-linux-gnu", "powerpc64le-unknown-linux-gnu",
 -      "powerpc64le-suse-linux", "ppc64le-redhat-linux"};
-+      "powerpc64le-suse-linux", "ppc64le-redhat-linux", "powerpc64le-conda_cos7-linux-gnu"};
++      "powerpc64le-suse-linux", "ppc64le-redhat-linux", "powerpc64le-conda_cos7-linux-gnu", "powerpc64le-conda-linux-gnu"};
  
    static const char *const RISCV32LibDirs[] = {"/lib", "/lib32"};
    static const char *const RISCVTriples[] = {"riscv32-unknown-linux-gnu",


### PR DESCRIPTION
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] ~~Reset the build number to `0` (if the version changed)~~
* [ ] ~~[Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)~~
* [ ] ~~Ensured the license file is being packaged.~~

Clang 8.x and 9.x are commonly used for building numerical libraries in Linux environments as versions 10.x and 11.x of CUDA  have an explicit dependency on them. However building software in a Conda environment with the `clang` compiler distributed as part of the clang Conda package fails with versions 8.x and 9.x due to missing  `*-conda-linux-gnu` GCC prefixes in the `0001-Find-conda-gcc-installation.patch` file. This PR backports these prefixes from the master branch to the 8.x branch to mitigate the issue.