### PR TITLE
feat: include clang-format as a stripped package

### DIFF
--- a/recipe/install_clang_tools.sh
+++ b/recipe/install_clang_tools.sh
@@ -6,7 +6,10 @@ cd $PREFIX
 rm -rf lib/cmake include lib/lib*.a
 MAJOR_VERSION=$(echo ${PKG_VERSION} | cut -f1 -d".")
 for f in ${PREFIX}/bin/clang-*; do
-    rm -f $(basename $f)-${MAJOR_VERSION}
-    mv $f $(basename $f)-${MAJOR_VERSION};
-    ln -s $(basename $f)-${MAJOR_VERSION} $f;
+    rm -f ${PREFIX}/bin/$(basename $f)-${MAJOR_VERSION}
+    mv $f ${PREFIX}/bin/$(basename $f)-${MAJOR_VERSION};
+    ln -s ${PREFIX}/bin/$(basename $f)-${MAJOR_VERSION} $f;
 done
+rm ${PREFIX}/bin/clang-${MAJOR_VERSION}-${MAJOR_VERSION}
+rm ${PREFIX}/bin/clang-cpp-${MAJOR_VERSION}
+rm ${PREFIX}/bin/clang-cl-${MAJOR_VERSION}

--- a/recipe/install_clang_tools.sh
+++ b/recipe/install_clang_tools.sh
@@ -6,5 +6,7 @@ cd $PREFIX
 rm -rf lib/cmake include lib/lib*.a
 MAJOR_VERSION=$(echo ${PKG_VERSION} | cut -f1 -d".")
 for f in ${PREFIX}/bin/clang-*; do
-    ln -s $f $(basename $f)-${MAJOR_VERSION};
+    rm -f $(basename $f)-${MAJOR_VERSION}
+    mv $f $(basename $f)-${MAJOR_VERSION};
+    ln -s $(basename $f)-${MAJOR_VERSION} $f;
 done

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -325,6 +325,28 @@ outputs:
         - clang-check --version
         - clang-tidy --version
 
+  - name: clang-format
+    build:
+      track_features:
+        - hcc          # [variant=="hcc"]
+      string: {{ variant }}_h{{ PKG_HASH }}_{{ build_number }}
+    files:
+      - bin/clang-format
+      - bin/clang-format-{{ major_version }}
+      - lib/lib/libclang-cpp.so.{{ major_version }}
+      - lib/lib/libclang.so.{{ major_version }}
+      - lib/libLLVM-{{ major_version }}.so
+      - lib/libstdc++*
+      - lib/libgfortran*
+    requirements:
+      run:
+        - {{ pin_subpackage("libclang-cpp" + minor_aware_ext, max_pin="x.x") }}   # [unix]
+      run_constrained:
+        - clangdev {{ version }}
+    test:
+      commands:
+        - clang-format --version
+
   - name: python-clang
     build:
       noarch: python

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -325,6 +325,43 @@ outputs:
       commands:
         - clang-format-{{ major_version }} --version
 
+  - name: clang-format
+    script: install_clang_tools.sh  # [unix]
+    script: install_clang_tools.bat  # [win]
+    build:
+      track_features:
+        - hcc          # [variant=="hcc"]
+      string: {{ variant }}_h{{ PKG_HASH }}_{{ build_number }}
+    files:
+      - bin/clang-format      # [unix]
+      - bin/clang-format.exe  # [win]
+    requirements:
+      build:
+        # "compiling .pyc files" fails without this
+        - python >3
+        - {{ compiler('cxx') }}
+        - cmake >=3.4.3
+        - ninja  # [win]
+        - make   # [unix]
+        - llvmdev =={{ version }}    # [build_platform != target_platform]
+      host:
+        - {{ pin_subpackage("clang", exact=True) }}
+        - {{ pin_subpackage("clangxx", exact=True) }}
+        - {{ pin_subpackage("libclang", exact=True) }}
+        - {{ pin_subpackage("libclang-cpp", exact=True) }}
+        - {{ pin_subpackage("clang-format-" + major_version, exact=True) }}   # [unix]
+        - libcxx {{ cxx_compiler_version }}  # [osx]
+        - llvmdev =={{ version }}
+        - llvm =={{ version }}
+        - zlib                            # [win]
+      run:
+        - {{ pin_compatible("libcxx", max_pin=None) }}  # [osx]
+        - {{ pin_subpackage("libclang-cpp" + minor_aware_ext, max_pin="x.x") }}   # [unix]
+        - {{ pin_subpackage("clang-format-" + major_version, exact=True) }}   # [unix]
+    test:
+      commands:
+        - clang-format --version
+
   - name: clang-tools
     script: install_clang_tools.sh  # [unix]
     script: install_clang_tools.bat  # [win]
@@ -346,14 +383,14 @@ outputs:
         - {{ pin_subpackage("clangxx", exact=True) }}
         - {{ pin_subpackage("libclang", exact=True) }}
         - {{ pin_subpackage("libclang-cpp", exact=True) }}
-        - {{ pin_subpackage("clang-format-" + major_version, exact=True) }}  # [unix]
+        - {{ pin_subpackage("clang-format", exact=True) }}
         - libcxx {{ cxx_compiler_version }}  # [osx]
         - llvmdev =={{ version }}
         - llvm =={{ version }}
         - zlib                            # [win]
       run:
         - {{ pin_compatible("libcxx", max_pin=None) }}  # [osx]
-        - {{ pin_subpackage("clang-format-" + major_version, exact=True) }}  # [unix]
+        - {{ pin_subpackage("clang-format", exact=True) }}
         - {{ pin_subpackage("libclang-cpp" + minor_aware_ext, max_pin="x.x") }}   # [unix]
         - libclang {{ minor_aware_ext }}.*   # [unix]
       run_constrained:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -289,13 +289,17 @@ outputs:
         - clang++ --version
         - clang++ -v -c mytest.cxx
 
-  - name: clang-tools
+  - name: clang-format-{{ major_version }}
     script: install_clang_tools.sh  # [unix]
     script: install_clang_tools.bat  # [win]
     build:
       track_features:
         - hcc          # [variant=="hcc"]
       string: {{ variant }}_h{{ PKG_HASH }}_{{ build_number }}
+      # for windows, use the clang-tools package.
+      skip: True  # [win]
+    files:
+      - bin/clang-format-{{ major_version }}
     requirements:
       build:
         # "compiling .pyc files" fails without this
@@ -317,6 +321,40 @@ outputs:
       run:
         - {{ pin_compatible("libcxx", max_pin=None) }}  # [osx]
         - {{ pin_subpackage("libclang-cpp" + minor_aware_ext, max_pin="x.x") }}   # [unix]
+    test:
+      commands:
+        - clang-format-{{ major_version }} --version
+
+  - name: clang-tools
+    script: install_clang_tools.sh  # [unix]
+    script: install_clang_tools.bat  # [win]
+    build:
+      track_features:
+        - hcc          # [variant=="hcc"]
+      string: {{ variant }}_h{{ PKG_HASH }}_{{ build_number }}
+    requirements:
+      build:
+        # "compiling .pyc files" fails without this
+        - python >3
+        - {{ compiler('cxx') }}
+        - cmake >=3.4.3
+        - ninja  # [win]
+        - make   # [unix]
+        - llvmdev =={{ version }}    # [build_platform != target_platform]
+      host:
+        - {{ pin_subpackage("clang", exact=True) }}
+        - {{ pin_subpackage("clangxx", exact=True) }}
+        - {{ pin_subpackage("libclang", exact=True) }}
+        - {{ pin_subpackage("libclang-cpp", exact=True) }}
+        - {{ pin_subpackage("clang-format-" + major_version, exact=True) }}  # [unix]
+        - libcxx {{ cxx_compiler_version }}  # [osx]
+        - llvmdev =={{ version }}
+        - llvm =={{ version }}
+        - zlib                            # [win]
+      run:
+        - {{ pin_compatible("libcxx", max_pin=None) }}  # [osx]
+        - {{ pin_subpackage("clang-format-" + major_version, exact=True) }}  # [unix]
+        - {{ pin_subpackage("libclang-cpp" + minor_aware_ext, max_pin="x.x") }}   # [unix]
         - libclang {{ minor_aware_ext }}.*   # [unix]
       run_constrained:
         - clangdev {{ version }}
@@ -324,28 +362,6 @@ outputs:
       commands:
         - clang-check --version
         - clang-tidy --version
-
-  - name: clang-format
-    build:
-      track_features:
-        - hcc          # [variant=="hcc"]
-      string: {{ variant }}_h{{ PKG_HASH }}_{{ build_number }}
-    files:
-      - bin/clang-format
-      - bin/clang-format-{{ major_version }}
-      - lib/lib/libclang-cpp.so.{{ major_version }}
-      - lib/lib/libclang.so.{{ major_version }}
-      - lib/libLLVM-{{ major_version }}.so
-      - lib/libstdc++*
-      - lib/libgfortran*
-    requirements:
-      run:
-        - {{ pin_subpackage("libclang-cpp" + minor_aware_ext, max_pin="x.x") }}   # [unix]
-      run_constrained:
-        - clangdev {{ version }}
-    test:
-      commands:
-        - clang-format --version
 
   - name: python-clang
     build:


### PR DESCRIPTION
Working on the stripped package mentioned #147 to allow a much lighter weight clang-format package for use in tools like pre-commit.

Not sure about quite a few things, but hopefully this is a start. I'm not sure where the files are coming from - I'd like to reuse them from the ones built in clang-tools if possible - and it seems like there are there, except the tests show `clang-format` missing when I build it locally.
