### PR TITLE
ensure we don't package libclang with full (so)version

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -215,11 +215,16 @@ outputs:
         - if exist %LIBRARY_BIN%\\libclang.dll exit 1                      # [win]
         - if exist %LIBRARY_LIB%\\libclang.lib exit 1                      # [win]
 
-        # absence of major version if soversion is different
         {% if libclang_soversion != major_version %}
+        # absence of major version if soversion is different
         - test ! -f "$PREFIX/lib/libclang.so.{{ major_version }}"          # [linux]
         - test ! -f "$PREFIX/lib/libclang.{{ major_version }}.dylib"       # [osx]
         - if exist %LIBRARY_BIN%\\libclang-{{ major_version }}.dll exit 1  # [win]
+
+        # same for full version (i.e. with major that doesn't match soversion)
+        - test ! -f "$PREFIX/lib/libclang.so.{{ version }}"                # [linux]
+        - test ! -f "$PREFIX/lib/libclang.{{ version }}.dylib"             # [osx]
+        - if exist %LIBRARY_BIN%\\libclang-{{ version }}.dll exit 1        # [win]
         {% endif %}
 
   - name: libclang

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set version = "15.0.7" %}
 {% set major_version = version.split(".")[0] %}
-{% set build_number = 0 %}
+{% set build_number = 1 %}
 
 {% set minor_aware_ext = major_version %}
 {% if version.split(".")[1] | int > 0 %}

--- a/recipe/patches/0001-Find-conda-gcc-installation.patch
+++ b/recipe/patches/0001-Find-conda-gcc-installation.patch
@@ -1,4 +1,4 @@
-From d5bac3f57633587b3d055ced43cd3fc6d6ebd162 Mon Sep 17 00:00:00 2001
+From 5116e043efa78df8e10ef26f68f79c05a931c653 Mon Sep 17 00:00:00 2001
 From: Isuru Fernando <isuruf@gmail.com>
 Date: Mon, 8 Apr 2019 16:20:03 -0500
 Subject: [PATCH 1/8] Find conda gcc installation
@@ -8,10 +8,10 @@ Subject: [PATCH 1/8] Find conda gcc installation
  1 file changed, 4 insertions(+), 3 deletions(-)
 
 diff --git a/clang/lib/Driver/ToolChains/Gnu.cpp b/clang/lib/Driver/ToolChains/Gnu.cpp
-index f203cae1d329..c750e6844ca0 100644
+index 665cdc3132..f401a2a435 100644
 --- a/clang/lib/Driver/ToolChains/Gnu.cpp
 +++ b/clang/lib/Driver/ToolChains/Gnu.cpp
-@@ -2188,7 +2188,7 @@ void Generic_GCC::GCCInstallationDetector::AddDefaultGCCPrefixes(
+@@ -2178,7 +2178,7 @@ void Generic_GCC::GCCInstallationDetector::AddDefaultGCCPrefixes(
    static const char *const AArch64LibDirs[] = {"/lib64", "/lib"};
    static const char *const AArch64Triples[] = {
        "aarch64-none-linux-gnu", "aarch64-linux-gnu", "aarch64-redhat-linux",
@@ -20,7 +20,7 @@ index f203cae1d329..c750e6844ca0 100644
    static const char *const AArch64beLibDirs[] = {"/lib"};
    static const char *const AArch64beTriples[] = {"aarch64_be-none-linux-gnu",
                                                   "aarch64_be-linux-gnu"};
-@@ -2218,7 +2218,8 @@ void Generic_GCC::GCCInstallationDetector::AddDefaultGCCPrefixes(
+@@ -2208,7 +2208,8 @@ void Generic_GCC::GCCInstallationDetector::AddDefaultGCCPrefixes(
        "x86_64-redhat-linux",    "x86_64-suse-linux",
        "x86_64-manbo-linux-gnu", "x86_64-linux-gnu",
        "x86_64-slackware-linux", "x86_64-unknown-linux",
@@ -30,7 +30,7 @@ index f203cae1d329..c750e6844ca0 100644
    static const char *const X32Triples[] = {"x86_64-linux-gnux32",
                                             "x86_64-pc-linux-gnux32"};
    static const char *const X32LibDirs[] = {"/libx32", "/lib"};
-@@ -2281,7 +2282,7 @@ void Generic_GCC::GCCInstallationDetector::AddDefaultGCCPrefixes(
+@@ -2271,7 +2272,7 @@ void Generic_GCC::GCCInstallationDetector::AddDefaultGCCPrefixes(
    static const char *const PPC64LETriples[] = {
        "powerpc64le-linux-gnu", "powerpc64le-unknown-linux-gnu",
        "powerpc64le-none-linux-gnu", "powerpc64le-suse-linux",
@@ -40,5 +40,5 @@ index f203cae1d329..c750e6844ca0 100644
    static const char *const RISCV32LibDirs[] = {"/lib32", "/lib"};
    static const char *const RISCV32Triples[] = {"riscv32-unknown-linux-gnu",
 -- 
-2.37.0.windows.1
+2.38.1.windows.1
 

--- a/recipe/patches/0002-Fix-sysroot-detection-for-linux.patch
+++ b/recipe/patches/0002-Fix-sysroot-detection-for-linux.patch
@@ -1,4 +1,4 @@
-From b74e506cc8724c5a5a8f33ab3dcb135f850721e2 Mon Sep 17 00:00:00 2001
+From 6c5e756505e09c0d4b8fde73c0692f2bf24823b1 Mon Sep 17 00:00:00 2001
 From: Isuru Fernando <isuruf@gmail.com>
 Date: Mon, 8 Apr 2019 16:32:17 -0500
 Subject: [PATCH 2/8] Fix sysroot detection for linux
@@ -8,7 +8,7 @@ Subject: [PATCH 2/8] Fix sysroot detection for linux
  1 file changed, 8 insertions(+)
 
 diff --git a/clang/lib/Driver/ToolChains/Linux.cpp b/clang/lib/Driver/ToolChains/Linux.cpp
-index ceb1a982c3a4..d6f62ec0acd6 100644
+index ceb1a982c3..d6f62ec0ac 100644
 --- a/clang/lib/Driver/ToolChains/Linux.cpp
 +++ b/clang/lib/Driver/ToolChains/Linux.cpp
 @@ -394,6 +394,14 @@ std::string Linux::computeSysRoot() const {
@@ -27,5 +27,5 @@ index ceb1a982c3a4..d6f62ec0acd6 100644
  
    if (getVFS().exists(Path))
 -- 
-2.37.0.windows.1
+2.38.1.windows.1
 

--- a/recipe/patches/0003-clang-add-conda-specific-env-var-CONDA_BUILD_SYSROOT.patch
+++ b/recipe/patches/0003-clang-add-conda-specific-env-var-CONDA_BUILD_SYSROOT.patch
@@ -1,4 +1,4 @@
-From e1712797c251d63724934dbb790fee7af541c72d Mon Sep 17 00:00:00 2001
+From cf8994afb833fb385d2e9428e06a82db6b761c9e Mon Sep 17 00:00:00 2001
 From: Nehal J Wani <nehaljw.kkd1@gmail.com>
 Date: Sat, 25 Aug 2018 09:20:04 -0500
 Subject: [PATCH 3/8] clang: add conda specific env var CONDA_BUILD_SYSROOT
@@ -9,7 +9,7 @@ Subject: [PATCH 3/8] clang: add conda specific env var CONDA_BUILD_SYSROOT
  2 files changed, 12 insertions(+), 3 deletions(-)
 
 diff --git a/clang/lib/Driver/Driver.cpp b/clang/lib/Driver/Driver.cpp
-index 3f29afd35971..94b4c6459478 100644
+index 3f29afd359..94b4c64594 100644
 --- a/clang/lib/Driver/Driver.cpp
 +++ b/clang/lib/Driver/Driver.cpp
 @@ -1270,8 +1270,13 @@ Compilation *Driver::BuildCompilation(ArrayRef<const char *> ArgList) {
@@ -29,7 +29,7 @@ index 3f29afd35971..94b4c6459478 100644
      DyldPrefix = A->getValue();
  
 diff --git a/clang/lib/Lex/InitHeaderSearch.cpp b/clang/lib/Lex/InitHeaderSearch.cpp
-index 158b5667151f..a3ab5f8f18b2 100644
+index 158b566715..a3ab5f8f18 100644
 --- a/clang/lib/Lex/InitHeaderSearch.cpp
 +++ b/clang/lib/Lex/InitHeaderSearch.cpp
 @@ -25,6 +25,7 @@
@@ -53,5 +53,5 @@ index 158b5667151f..a3ab5f8f18b2 100644
      }
    }
 -- 
-2.37.0.windows.1
+2.38.1.windows.1
 

--- a/recipe/patches/0004-Fix-normalizeProgramName-s-handling-of-dots-outside-.patch
+++ b/recipe/patches/0004-Fix-normalizeProgramName-s-handling-of-dots-outside-.patch
@@ -1,4 +1,4 @@
-From 71557667efee4bbead3b681312a0dacda2a581b7 Mon Sep 17 00:00:00 2001
+From 97a6c17c20d867b6f8541fa9a6aaaceb5ecc3e03 Mon Sep 17 00:00:00 2001
 From: Ray Donnelly <mingw.android@gmail.com>
 Date: Wed, 30 Aug 2017 20:01:49 +0100
 Subject: [PATCH 4/8] Fix normalizeProgramName()'s handling of dots outside of
@@ -18,7 +18,7 @@ x86_64-apple-darwin13.4
  1 file changed, 22 insertions(+), 1 deletion(-)
 
 diff --git a/clang/lib/Driver/ToolChain.cpp b/clang/lib/Driver/ToolChain.cpp
-index 7a4319ea680f..97b1a8c6341e 100644
+index 7a4319ea68..97b1a8c634 100644
 --- a/clang/lib/Driver/ToolChain.cpp
 +++ b/clang/lib/Driver/ToolChain.cpp
 @@ -50,6 +50,7 @@ using namespace driver;
@@ -62,5 +62,5 @@ index 7a4319ea680f..97b1a8c6341e 100644
      // Transform to lowercase for case insensitive file systems.
      std::transform(ProgName.begin(), ProgName.end(), ProgName.begin(),
 -- 
-2.37.0.windows.1
+2.38.1.windows.1
 

--- a/recipe/patches/0005-Set-VERSION-in-osx-as-well.patch
+++ b/recipe/patches/0005-Set-VERSION-in-osx-as-well.patch
@@ -1,4 +1,4 @@
-From 84b4251f8277afcd5f8b2415c70867201e44d110 Mon Sep 17 00:00:00 2001
+From 46e79dbf6a67497c9798b090603ebee231aa7b7b Mon Sep 17 00:00:00 2001
 From: Isuru Fernando <isuruf@gmail.com>
 Date: Sat, 27 Jul 2019 11:55:23 -0500
 Subject: [PATCH 5/8] Set VERSION in osx as well
@@ -8,7 +8,7 @@ Subject: [PATCH 5/8] Set VERSION in osx as well
  1 file changed, 5 insertions(+)
 
 diff --git a/clang/tools/libclang/CMakeLists.txt b/clang/tools/libclang/CMakeLists.txt
-index c6b3b44a7633..f234f15628e7 100644
+index c6b3b44a76..f234f15628 100644
 --- a/clang/tools/libclang/CMakeLists.txt
 +++ b/clang/tools/libclang/CMakeLists.txt
 @@ -170,6 +170,11 @@ if(ENABLE_SHARED)
@@ -24,5 +24,5 @@ index c6b3b44a7633..f234f15628e7 100644
      set_target_properties(libclang
        PROPERTIES
 -- 
-2.37.0.windows.1
+2.38.1.windows.1
 

--- a/recipe/patches/0006-Fix-crosscompiling-LLVM-tools.patch
+++ b/recipe/patches/0006-Fix-crosscompiling-LLVM-tools.patch
@@ -1,4 +1,4 @@
-From d287e85165e4b45b4bdccf54a1b4bb18621095e8 Mon Sep 17 00:00:00 2001
+From 8117f6dcbabbfe3c97048105caa43c31347f2200 Mon Sep 17 00:00:00 2001
 From: Isuru Fernando <isuruf@gmail.com>
 Date: Tue, 11 May 2021 15:08:13 +0200
 Subject: [PATCH 6/8] Fix crosscompiling LLVM tools
@@ -8,7 +8,7 @@ Subject: [PATCH 6/8] Fix crosscompiling LLVM tools
  1 file changed, 10 insertions(+)
 
 diff --git a/clang/CMakeLists.txt b/clang/CMakeLists.txt
-index 13d76e7fd935..dcb9b7de2944 100644
+index e3bc4b468f..078a45a1ce 100644
 --- a/clang/CMakeLists.txt
 +++ b/clang/CMakeLists.txt
 @@ -114,6 +114,16 @@ if(CLANG_BUILT_STANDALONE)
@@ -29,5 +29,5 @@ index 13d76e7fd935..dcb9b7de2944 100644
    include(HandleLLVMOptions)
    include(VersionFromVCS)
 -- 
-2.37.0.windows.1
+2.38.1.windows.1
 

--- a/recipe/patches/0007-Only-error-on-undefined-TARGET_OS_OSX.patch
+++ b/recipe/patches/0007-Only-error-on-undefined-TARGET_OS_OSX.patch
@@ -1,4 +1,4 @@
-From 3b5eb6559cca06dc36a412bdfe183fd66409e4e5 Mon Sep 17 00:00:00 2001
+From 5ceec06db7473c3703d9d540e7d6b884ef8d0b09 Mon Sep 17 00:00:00 2001
 From: "Uwe L. Korn" <uwe.korn@quantco.com>
 Date: Tue, 11 May 2021 15:09:51 +0200
 Subject: [PATCH 7/8] Only error on undefined TARGET_OS_OSX
@@ -8,7 +8,7 @@ Subject: [PATCH 7/8] Only error on undefined TARGET_OS_OSX
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/clang/lib/Driver/ToolChains/Darwin.cpp b/clang/lib/Driver/ToolChains/Darwin.cpp
-index bada811daadf..c4dc8054b181 100644
+index bada811daa..c4dc8054b1 100644
 --- a/clang/lib/Driver/ToolChains/Darwin.cpp
 +++ b/clang/lib/Driver/ToolChains/Darwin.cpp
 @@ -1092,7 +1092,7 @@ DarwinClang::DarwinClang(const Driver &D, const llvm::Triple &Triple,
@@ -21,5 +21,5 @@ index bada811daadf..c4dc8054b181 100644
  
    // For modern targets, promote certain warnings to errors.
 -- 
-2.37.0.windows.1
+2.38.1.windows.1
 

--- a/recipe/patches/0008-set-libclang-SOVERSION-unconditionally.patch
+++ b/recipe/patches/0008-set-libclang-SOVERSION-unconditionally.patch
@@ -1,17 +1,18 @@
-From 2293d456076cbc8af204423ccd92d46c254872ef Mon Sep 17 00:00:00 2001
+From d6752559bc3a921e5d42c020878b258c04a19501 Mon Sep 17 00:00:00 2001
 From: "H. Vetinari" <h.vetinari@gmx.com>
 Date: Thu, 14 Apr 2022 11:57:00 +1100
 Subject: [PATCH 8/8] set libclang SOVERSION unconditionally
 
+and avoid creating libclang with full version suffix
 ---
- clang/tools/libclang/CMakeLists.txt | 6 ++++++
- 1 file changed, 6 insertions(+)
+ clang/tools/libclang/CMakeLists.txt | 9 ++++++++-
+ 1 file changed, 8 insertions(+), 1 deletion(-)
 
 diff --git a/clang/tools/libclang/CMakeLists.txt b/clang/tools/libclang/CMakeLists.txt
-index f234f15628e7..a170f8838924 100644
+index f234f15628..4aa1e77eac 100644
 --- a/clang/tools/libclang/CMakeLists.txt
 +++ b/clang/tools/libclang/CMakeLists.txt
-@@ -197,7 +197,13 @@ if(ENABLE_SHARED)
+@@ -197,9 +197,16 @@ if(ENABLE_SHARED)
      # Ensure that libclang.so gets rebuilt when the linker script changes.
      set_property(SOURCE ARCMigrate.cpp APPEND PROPERTY
                   OBJECT_DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/libclang.map)
@@ -21,10 +22,14 @@ index f234f15628e7..a170f8838924 100644
 +    # point libclang.lib to libclang-<SO-version>.dll
 +    set_target_properties(libclang PROPERTIES RUNTIME_OUTPUT_NAME "libclang-${LIBCLANG_SOVERSION}")
 +  else()
-+    # on unix, set so-version directly
++    # on unix, set soversion directly (also need to set version
++    # to avoid libclang.so.LLVM_VERSION_MAJOR being generated)
      set_target_properties(libclang PROPERTIES
-                           VERSION ${LLVM_VERSION_MAJOR}.${LLVM_VERSION_MINOR}.${LLVM_VERSION_PATCH}${LLVM_VERSION_SUFFIX}
+-                          VERSION ${LLVM_VERSION_MAJOR}.${LLVM_VERSION_MINOR}.${LLVM_VERSION_PATCH}${LLVM_VERSION_SUFFIX}
++                          VERSION ${LIBCLANG_SOVERSION}
                            SOVERSION ${LIBCLANG_SOVERSION})
+   endif()
+ endif()
 -- 
-2.37.0.windows.1
+2.38.1.windows.1
 


### PR DESCRIPTION
Noticed just now that the full-versioned libs had [slipped through](https://github.com/regro/libcfgraph/blob/master/artifacts/libclang13/conda-forge/linux-64/libclang13-15.0.7-default_h3e3d535_0.json#L226-L229) the versioned libclang13 effort.

FYI @isuruf

