### PR TITLE
Fix sysroot issue about CONDA_BUILD_SYSROOT

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -615,6 +615,7 @@ extra:
     - inducer
     - isuruf
     - jakirkham
+    - katietz
     - SylvainCorlay
     - timsnyder
     - chrisburr

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set version = "16.0.3" %}
 {% set major_version = version.split(".")[0] %}
-{% set build_number = 0 %}
+{% set build_number = 1 %}
 
 {% set minor_aware_ext = major_version %}
 {% if version.split(".")[1] | int > 0 %}

--- a/recipe/patches/0003-clang-add-conda-specific-env-var-CONDA_BUILD_SYSROOT.patch
+++ b/recipe/patches/0003-clang-add-conda-specific-env-var-CONDA_BUILD_SYSROOT.patch
@@ -21,10 +21,10 @@ index 661d9977fb..f5a75515ed 100644
 +  if (Optional<std::string> CondaBuildSysrootValue =
 +          llvm::sys::Process::GetEnv("CONDA_BUILD_SYSROOT")) {
 +    SysRoot = *CondaBuildSysrootValue;
-+  } else {
-+    if (const Arg *A = Args.getLastArg(options::OPT__sysroot_EQ))
-+      SysRoot = A->getValue();
 +  }
++  // Override CONDA_BUILD_SYSROOT and consume sysroot option
++  if (const Arg *A = Args.getLastArg(options::OPT__sysroot_EQ))
++    SysRoot = A->getValue();
    if (const Arg *A = Args.getLastArg(options::OPT__dyld_prefix_EQ))
      DyldPrefix = A->getValue();
  


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

This issue fixes that if the environment variable CONDA_BUILD_SYSROOT is defined, the '-sysroot' option passed as argument is ignored and even leads to an unused-command-line-argument warning for it.
This issue is especially problematic in cross-compiler scenario - like emscripten - where it is essential to be able to switch between native and cross' sysroot by the '-sysroot' option on demand.

As this issue is a long standing one, we might even want to backport it to older versions, but this is for now out of scope for this patch