### PR TITLE
[16.x] package `$TRIPLE-clang-cpp` symlink on linux

### DIFF
--- a/recipe/install_clang_symlinks.sh
+++ b/recipe/install_clang_symlinks.sh
@@ -10,5 +10,8 @@ if [[ "$target_platform" == "linux-"* ]]; then
   source ${RECIPE_DIR}/get_cpu_triplet.sh
   CHOST=$(get_triplet $target_platform)
   ln -s "${PREFIX}/bin/clang-${maj_version}" "${PREFIX}/bin/${CHOST}-clang"
+  ln -s "${PREFIX}/bin/clang-${maj_version}" "${PREFIX}/bin/${CHOST}-clang-cpp"
+  # for background, see comment in install_clangxx.sh
   echo "--sysroot ${PREFIX}/${CHOST}/sysroot" >> ${PREFIX}/bin/${CHOST}-clang.cfg
+  echo "--sysroot ${PREFIX}/${CHOST}/sysroot" >> ${PREFIX}/bin/${CHOST}-clang-cpp.cfg
 fi

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set version = "16.0.6" %}
 {% set major_version = version.split(".")[0] %}
-{% set build_number = 10 %}
+{% set build_number = 11 %}
 
 {% set minor_aware_ext = major_version %}
 {% if version.split(".")[1] | int > 0 %}
@@ -493,6 +493,13 @@ outputs:
         - clang --version
         - clang-cl --version
         - clang-cpp --version
+        # on linux, $TRIPLE-clang{,-cpp} are in this package
+        - x86_64-conda-linux-gnu-clang --version            # [linux64]
+        - x86_64-conda-linux-gnu-clang-cpp --version        # [linux64]
+        - aarch64-conda-linux-gnu-clang --version           # [aarch64]
+        - aarch64-conda-linux-gnu-clang-cpp --version       # [aarch64]
+        - powerpc64le-conda-linux-gnu-clang --version       # [ppc64le]
+        - powerpc64le-conda-linux-gnu-clang-cpp --version   # [ppc64le]
 
   - name: clangxx
     script: install_clangxx.sh  # [unix]
@@ -530,6 +537,10 @@ outputs:
         - unset CONDA_BUILD_SYSROOT   # [unix]
         - set "CONDA_BUILD_SYSROOT="  # [win]
         - clang++ -v -c mytest.cxx
+        # on linux, $TRIPLE-clang++ is in this package
+        - x86_64-conda-linux-gnu-clang++ --version          # [linux64]
+        - aarch64-conda-linux-gnu-clang++ --version         # [aarch64]
+        - powerpc64le-conda-linux-gnu-clang++ --version     # [ppc64le]
 
   - name: clang-format-{{ major_version }}
     script: install_clang_format.sh  # [unix]


### PR DESCRIPTION
Necessary for https://github.com/conda-forge/clang-compiler-activation-feedstock/pull/133; partial backport from #297