### PR TITLE
[13.x] Build with a newer libcxx on macOS

### DIFF
--- a/.ci_support/osx_64_variantdefault.yaml
+++ b/.ci_support/osx_64_variantdefault.yaml
@@ -13,7 +13,7 @@ channel_targets:
 cxx_compiler:
 - clang_bootstrap
 cxx_compiler_version:
-- '16'
+- '17'
 macos_machine:
 - x86_64-apple-darwin13.4.0
 target_platform:

--- a/.ci_support/osx_64_variantroot_63004.yaml
+++ b/.ci_support/osx_64_variantroot_63004.yaml
@@ -13,7 +13,7 @@ channel_targets:
 cxx_compiler:
 - clang_bootstrap
 cxx_compiler_version:
-- '16'
+- '17'
 macos_machine:
 - x86_64-apple-darwin13.4.0
 target_platform:

--- a/.ci_support/osx_arm64_variantdefault.yaml
+++ b/.ci_support/osx_arm64_variantdefault.yaml
@@ -13,7 +13,7 @@ channel_targets:
 cxx_compiler:
 - clang_bootstrap
 cxx_compiler_version:
-- '16'
+- '17'
 macos_machine:
 - arm64-apple-darwin20.0.0
 target_platform:

--- a/.ci_support/osx_arm64_variantroot_63004.yaml
+++ b/.ci_support/osx_arm64_variantroot_63004.yaml
@@ -13,7 +13,7 @@ channel_targets:
 cxx_compiler:
 - clang_bootstrap
 cxx_compiler_version:
-- '16'
+- '17'
 macos_machine:
 - arm64-apple-darwin20.0.0
 target_platform:

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -2,9 +2,9 @@ cxx_compiler:           # [osx]
   - clang_bootstrap     # [osx]
 
 cxx_compiler_version:   # [osx or linux]
-  # use an old-enough compiler that allows us
-  # to restrict libcxx version
-  - 16                  # [osx]
+  # use a compiler that allows us to pin to a libcxx that is compatible with
+  # https://github.com/conda-forge/conda-forge-pinning-feedstock/blob/main/recipe/conda_build_config.yaml
+  - 17                  # [osx]
   # linking error with gcc 9
   - 8                   # [linux]
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set version = "13.0.1" %}
 {% set major_version = version.split(".")[0] %}
-{% set build_number = 7 %}
+{% set build_number = 8 %}
 
 {% set minor_aware_ext = major_version %}
 {% set minor_int = version.split(".")[1] | int %}


### PR DESCRIPTION
since
https://github.com/conda-forge/conda-forge-pinning-feedstock/commit/408e182a971b21e5f784daa05078ff3c0d475646 forces a more modern libcxx on macOS, pinning here to libcxx breaks downstream packages such as cppyy, see https://github.com/conda-forge/cppyy-cling-feedstock/pull/62#issuecomment-2305187040

As indicated in
https://github.com/conda-forge/clangdev-feedstock/pull/300#issuecomment-2283805407 there should be no problem using libcxx 17 here as well.

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
