### PR TITLE
[main] switch to using libcxx-devel

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set version = "18.1.8" %}
 {% set major_version = version.split(".")[0] %}
-{% set build_number = 2 %}
+{% set build_number = 3 %}
 
 # always includes minor as of v18, see https://github.com/llvm/llvm-project/issues/76273
 {% set minor_aware_ext = major_version ~ "." ~ version.split(".")[1] %}
@@ -54,7 +54,7 @@ requirements:
     - zlib                       # [build_platform != target_platform]
     - zstd                       # [build_platform != target_platform]
   host:
-    - libcxx {{ cxx_compiler_version }}  # [osx]
+    - libcxx-devel {{ cxx_compiler_version }}   # [osx]
     - llvmdev =={{ version }}
     - libxml2
     - zlib
@@ -88,7 +88,7 @@ outputs:
         - {{ pin_subpackage("libclang", exact=True) }}
         - {{ pin_subpackage("libclang-cpp", exact=True) }}
         # Use the same requirements as the top-level requirements
-        - libcxx {{ cxx_compiler_version }}  # [osx]
+        - libcxx-devel {{ cxx_compiler_version }}   # [osx]
         - llvmdev =={{ version }}
         - libxml2
         - zlib
@@ -99,8 +99,9 @@ outputs:
         - {{ pin_subpackage("clang-tools", exact=True) }}
         - {{ pin_subpackage("libclang", exact=True) }}
         - {{ pin_subpackage("libclang-cpp", exact=True) }}
-        - {{ pin_compatible("libcxx", max_pin=None) }}  # [osx]
         - llvmdev =={{ version }}
+        # we need to do this manually because clang_bootstrap has no run-export
+        - libcxx >={{ cxx_compiler_version }}       # [osx]
     test:
       requires:
         - {{ compiler('cxx') }}
@@ -157,13 +158,14 @@ outputs:
       host:
         - llvm =={{ version }}
         # Use the same requirements as the top-level requirements
-        - libcxx {{ cxx_compiler_version }}  # [osx]
+        - libcxx-devel {{ cxx_compiler_version }}  # [osx]
         - llvmdev =={{ version }}
         - libxml2
         - zlib
         - zstd
       run:
-        - {{ pin_compatible("libcxx", max_pin=None) }}  # [osx]
+        # we need to do this manually because clang_bootstrap has no run-export
+        - libcxx >={{ cxx_compiler_version }}       # [osx]
     test:
       commands:
         # presence of versioned library
@@ -203,14 +205,15 @@ outputs:
         - llvm =={{ version }}
         - {{ pin_subpackage("libclang-cpp" ~ minor_aware_ext, exact=True) }}  # [unix]
         # Use the same requirements as the top-level requirements
-        - libcxx {{ cxx_compiler_version }}  # [osx]
+        - libcxx-devel {{ cxx_compiler_version }}   # [osx]
         - llvmdev =={{ version }}
         - libxml2
         - zlib
         - zstd
       run:
-        - {{ pin_compatible("libcxx", max_pin=None) }}                        # [osx]
         - {{ pin_subpackage("libclang-cpp" ~ minor_aware_ext, exact=True) }}  # [unix]
+        # we need to do this manually because clang_bootstrap has no run-export
+        - libcxx >={{ cxx_compiler_version }}       # [osx]
     test:
       commands:
         # presence on unix
@@ -252,13 +255,14 @@ outputs:
         - llvm =={{ version }}
         - {{ pin_subpackage("clang", exact=True) }}
         # Use the same requirements as the top-level requirements
-        - libcxx {{ cxx_compiler_version }}  # [osx]
+        - libcxx-devel {{ cxx_compiler_version }}   # [osx]
         - llvmdev =={{ version }}
         - libxml2
         - zlib
         - zstd
       run:
-        - {{ pin_compatible("libcxx", max_pin=None) }}  # [osx]
+        # we need to do this manually because clang_bootstrap has no run-export
+        - libcxx >={{ cxx_compiler_version }}       # [osx]
     test:
       commands:
         # presence of versioned libraries
@@ -317,14 +321,15 @@ outputs:
         - {{ pin_subpackage("clang", exact=True) }}
         - {{ pin_subpackage("libclang" ~ libclang_soversion, exact=True) }}
         # Use the same requirements as the top-level requirements
-        - libcxx {{ cxx_compiler_version }}  # [osx]
+        - libcxx-devel {{ cxx_compiler_version }}   # [osx]
         - llvmdev =={{ version }}
         - libxml2
         - zlib
         - zstd
       run:
-        - {{ pin_compatible("libcxx", max_pin=None) }}                # [osx]
         - {{ pin_subpackage("libclang" ~ libclang_soversion, exact=True) }}
+        # we need to do this manually because clang_bootstrap has no run-export
+        - libcxx >={{ cxx_compiler_version }}       # [osx]
     test:
       commands:
         - test -f $PREFIX/lib/libclang.so                   # [linux]
@@ -355,20 +360,20 @@ outputs:
         - cmake
         - ninja                              # [win]
         - make                               # [unix]
-        - libcxx                             # [osx]
         - llvmdev =={{ version }}            # [build_platform != target_platform]
       host:
         - llvm =={{ version }}
         - {{ pin_subpackage("libclang-cpp" ~ minor_aware_ext, exact=True) }}  # [unix]
         # Use the same requirements as the top-level requirements
-        - libcxx {{ cxx_compiler_version }}  # [osx]
+        - libcxx-devel {{ cxx_compiler_version }}  # [osx]
         - llvmdev =={{ version }}
         - libxml2
         - zlib
         - zstd
       run:
-        - {{ pin_compatible("libcxx", max_pin=None) }}                        # [osx]
         - {{ pin_subpackage("libclang-cpp" ~ minor_aware_ext, exact=True) }}  # [unix]
+        # we need to do this manually because clang_bootstrap has no run-export
+        - libcxx >={{ cxx_compiler_version }}      # [osx]
     test:
       commands:
         # presence of versioned libraries
@@ -410,7 +415,7 @@ outputs:
       host:
         - {{ pin_subpackage("clang-" ~ major_version, exact=True) }}
         # Use the same requirements as the top-level requirements
-        - libcxx {{ cxx_compiler_version }}  # [osx]
+        - libcxx-devel {{ cxx_compiler_version }}   # [osx]
         - llvmdev =={{ version }}
         - libxml2
         - zlib
@@ -449,13 +454,14 @@ outputs:
       host:
         - {{ pin_subpackage("clang", exact=True) }}
         # Use the same requirements as the top-level requirements
-        - libcxx {{ cxx_compiler_version }}  # [osx]
+        - libcxx-devel {{ cxx_compiler_version }}   # [osx]
         - llvmdev =={{ version }}
         - libxml2
         - zlib
         - zstd
       run:
         - libstdcxx-devel_{{ target_platform }}  # [linux]
+        - libcxx-devel                           # [osx]
         - {{ pin_subpackage("clang", exact=True) }}
     test:
       requires:
@@ -504,14 +510,15 @@ outputs:
         - {{ pin_subpackage("libclang-cpp", exact=True) }}
         - llvm =={{ version }}
         # Use the same requirements as the top-level requirements
-        - libcxx {{ cxx_compiler_version }}  # [osx]
+        - libcxx-devel {{ cxx_compiler_version }}   # [osx]
         - llvmdev =={{ version }}
         - libxml2
         - zlib
         - zstd
       run:
-        - {{ pin_compatible("libcxx", max_pin=None) }}                            # [osx]
         - {{ pin_subpackage("libclang-cpp" ~ minor_aware_ext, max_pin="x.x") }}   # [unix]
+        # we need to do this manually because clang_bootstrap has no run-export
+        - libcxx >={{ cxx_compiler_version }}       # [osx]
     test:
       commands:
         - clang-format-{{ major_version }} --version
@@ -551,15 +558,16 @@ outputs:
         - {{ pin_subpackage("clang-format-" ~ major_version, exact=True) }}      # [unix]
         - llvm =={{ version }}
         # Use the same requirements as the top-level requirements
-        - libcxx {{ cxx_compiler_version }}  # [osx]
+        - libcxx-devel {{ cxx_compiler_version }}   # [osx]
         - llvmdev =={{ version }}
         - libxml2
         - zlib
         - zstd
       run:
-        - {{ pin_compatible("libcxx", max_pin=None) }}                           # [osx]
         - {{ pin_subpackage("libclang-cpp" ~ minor_aware_ext, max_pin="x.x") }}  # [unix]
         - {{ pin_subpackage("clang-format-" ~ major_version, exact=True) }}      # [unix]
+        # we need to do this manually because clang_bootstrap has no run-export
+        - libcxx >={{ cxx_compiler_version }}       # [osx]
     test:
       commands:
         - clang-format --version
@@ -595,17 +603,18 @@ outputs:
         - {{ pin_subpackage("clang-format", exact=True) }}
         - llvm =={{ version }}
         # Use the same requirements as the top-level requirements
-        - libcxx {{ cxx_compiler_version }}  # [osx]
+        - libcxx-devel {{ cxx_compiler_version }}  # [osx]
         - llvmdev =={{ version }}
         - libxml2
         - zlib
         - zstd
       run:
         - ucrt                                          # [win]
-        - {{ pin_compatible("libcxx", max_pin=None) }}  # [osx]
         - {{ pin_subpackage("clang-format", exact=True) }}
         - {{ pin_subpackage("libclang" ~ libclang_soversion, max_pin=None) }}
         - {{ pin_subpackage("libclang-cpp" ~ minor_aware_ext, max_pin="x.x") }}   # [unix]
+        # we need to do this manually because clang_bootstrap has no run-export
+        - libcxx >={{ cxx_compiler_version }}       # [osx]
       run_constrained:
         - clangdev {{ version }}
     test:


### PR DESCRIPTION
For #310, using builds from https://github.com/conda-forge/libcxx-feedstock/pull/183