### PR TITLE
[18.x] fix build w.r.t. libcxx-devel pins

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set version = "18.1.8" %}
 {% set major_version = version.split(".")[0] %}
-{% set build_number = 4 %}
+{% set build_number = 5 %}
 
 # always includes minor as of v18, see https://github.com/llvm/llvm-project/issues/76273
 {% set minor_aware_ext = major_version ~ "." ~ version.split(".")[1] %}
@@ -87,8 +87,9 @@ outputs:
         - {{ pin_subpackage("clang-tools", exact=True) }}
         - {{ pin_subpackage("libclang", exact=True) }}
         - {{ pin_subpackage("libclang-cpp", exact=True) }}
-        # unpinned because we depend on clangxx here, which pins libcxx-devel
-        - libcxx-devel              # [osx]
+        # cannot pin to `cxx_compiler_version` here,
+        # because clangxx pins libcxx-devel to `version`
+        - libcxx-devel =={{ version }}  # [osx]
         - llvmdev =={{ version }}
         - libxml2
         - zlib
@@ -508,9 +509,10 @@ outputs:
         - {{ pin_subpackage("clangxx", exact=True) }}
         - {{ pin_subpackage("libclang", exact=True) }}
         - {{ pin_subpackage("libclang-cpp", exact=True) }}
+        # cannot pin to `cxx_compiler_version` here,
+        # because clangxx pins libcxx-devel to `version`
+        - libcxx-devel =={{ version }}  # [osx]
         - llvm =={{ version }}
-        # unpinned because we depend on clangxx here, which pins libcxx-devel
-        - libcxx-devel              # [osx]
         - llvmdev =={{ version }}
         - libxml2
         - zlib
@@ -556,9 +558,10 @@ outputs:
         - {{ pin_subpackage("libclang", exact=True) }}
         - {{ pin_subpackage("libclang-cpp", exact=True) }}
         - {{ pin_subpackage("clang-format-" ~ major_version, exact=True) }}      # [unix]
+        # cannot pin to `cxx_compiler_version` here,
+        # because clangxx pins libcxx-devel to `version`
+        - libcxx-devel =={{ version }}  # [osx]
         - llvm =={{ version }}
-        # unpinned because we depend on clangxx here, which pins libcxx-devel
-        - libcxx-devel              # [osx]
         - llvmdev =={{ version }}
         - libxml2
         - zlib
@@ -601,9 +604,10 @@ outputs:
         - {{ pin_subpackage("libclang", exact=True) }}
         - {{ pin_subpackage("libclang-cpp", exact=True) }}
         - {{ pin_subpackage("clang-format", exact=True) }}
+        # cannot pin to `cxx_compiler_version` here,
+        # because clangxx pins libcxx-devel to `version`
+        - libcxx-devel =={{ version }}  # [osx]
         - llvm =={{ version }}
-        # unpinned because we depend on clangxx here, which pins libcxx-devel
-        - libcxx-devel              # [osx]
         - llvmdev =={{ version }}
         - libxml2
         - zlib


### PR DESCRIPTION
CI for the newly-created branch at 811977470f2c38120da8d6e353b1c3d64d691e88 failed in the presence of `libcxx 19`.

Give the solver a hand in figuring out how to resolve the environment.