### PR TITLE
[dev] Build using clang on windows

### DIFF
--- a/.ci_support/win_64_.yaml
+++ b/.ci_support/win_64_.yaml
@@ -5,7 +5,7 @@ channel_sources:
 channel_targets:
 - conda-forge llvm_dev
 cxx_compiler:
-- vs2019
+- clangxx
 libclang_soversion:
 - '13'
 libxml2:

--- a/.ci_support/win_64_.yaml
+++ b/.ci_support/win_64_.yaml
@@ -6,6 +6,8 @@ channel_targets:
 - conda-forge llvm_dev
 cxx_compiler:
 - clangxx
+cxx_compiler_version:
+- '19'
 libclang_soversion:
 - '13'
 libxml2:

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -22,8 +22,8 @@ cd build
 set "CFLAGS= -MD"
 set "CXXFLAGS= -MD"
 
-set "CXX=cl.exe"
-set "CC=cl.exe"
+set "CXX=clang-cl.exe"
+set "CC=clang-cl.exe"
 
 cmake -G "Ninja" ^
     -DCMAKE_BUILD_TYPE="Release" ^

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,7 +1,9 @@
-c_compiler:          # [osx]
+c_compiler:          # [osx or win]
   - clang_bootstrap  # [osx]
-cxx_compiler:        # [osx]
+  - clang            # [win]
+cxx_compiler:        # [osx or win]
   - clang_bootstrap  # [osx]
+  - clangxx          # [win]
 
 # Starting from LLVM 14, the ABI of libclang doesn't necessarily
 # match the major version anymore - cf. #170 and

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,9 +1,13 @@
-c_compiler:          # [osx or win]
-  - clang_bootstrap  # [osx]
-  - clang            # [win]
-cxx_compiler:        # [osx or win]
-  - clang_bootstrap  # [osx]
-  - clangxx          # [win]
+c_compiler:             # [osx or win]
+  - clang_bootstrap     # [osx]
+  - clang               # [win]
+cxx_compiler:           # [osx or win]
+  - clang_bootstrap     # [osx]
+  - clangxx             # [win]
+c_compiler_version:     # [win]
+  - 19                  # [win]
+cxx_compiler_version:   # [win]
+  - 19                  # [win]
 
 # Starting from LLVM 14, the ABI of libclang doesn't necessarily
 # match the major version anymore - cf. #170 and

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -45,6 +45,8 @@ source:
 
 build:
   number: {{ build_number }}
+  # debug
+  skip: true  # [not win]
 
 requirements:
   build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -590,6 +590,7 @@ outputs:
     script: install_clang_tools.sh  # [unix]
     script: install_clang_tools.bat  # [win]
     build:
+      skip: true  # [win]
       track_features:
         - root         # [variant and variant.startswith("root_")]
       string: {{ variant }}_h{{ PKG_HASH }}_{{ build_number }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -73,6 +73,7 @@ outputs:
     script: install_clangdev.sh  # [unix]
     script: install_clangdev.bat  # [win]
     build:
+      skip: true  # [win]
       track_features:
         - root         # [variant and variant.startswith("root_")]
       string: {{ variant }}_h{{ PKG_HASH }}_{{ build_number }}


### PR DESCRIPTION
The merge after #330 is OOM-ing despite a ~16GB swapfile (already 3 times; 1 in the PR, 2x after merge), so we've almost reached the end of the road in terms of options (unless this is an upstream regression since #329).

As a last resort we could turn down the build parallelism, but that will make it even more likely that windows builds run into timeouts. For now, see if compilation using `clang-cl` succeeds (which has shown to be much faster for building flang, for example).