### PR TITLE
TEST: reland of PR that broke MSVC

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "20.0.0.dev3" %}
+{% set version = "20.0.0.dev4" %}
 {% set major_version = version.split(".")[0] %}
 {% set tail_version = version.split(".")[-1] %}
 {% set build_number = 0 %}
@@ -23,8 +23,8 @@ package:
 
 source:
   # - url: https://github.com/llvm/llvm-project/archive/refs/tags/llvmorg-{{ version.replace(".rc", "-rc") }}.tar.gz
-  - url: https://github.com/llvm/llvm-project/archive/ca79ff07d8ae7a0c2531bfdb1cb623e25e5bd486.tar.gz
-    sha256: f306932aa74a61c34ae3c7238634de258fd3356d69a18269ee69336080061565
+  - url: https://github.com/llvm/llvm-project/archive/2bcc4e5f7043dab1ef673dd20b38009363db51db.tar.gz
+    sha256: 9fc989a5efa199c724ef3dcdf778c77c3c342312824df11f7bf81b291d89f6ba
     patches:
       - patches/0001-Find-conda-gcc-installation.patch
       - patches/0002-Fix-sysroot-detection-for-linux.patch


### PR DESCRIPTION
Test if the new version for the PR that caused https://github.com/llvm/llvm-project/issues/119781 works with MSVC now.

From https://github.com/chandlerc/llvm-project/tree/prefix-arm-rv