### PR TITLE
Fix finding omp.h without activating the environment

### DIFF
--- a/recipe/install_clang.sh
+++ b/recipe/install_clang.sh
@@ -3,3 +3,11 @@ set -ex
 
 cd ${SRC_DIR}/clang/build
 make install
+
+MAJOR_VERSION=$(echo ${PKG_VERSION} | cut -f1 -d".")
+if [[ ! -d $PREFIX/lib/clang/${MAJOR_VERSION}/include ]]; then
+  echo "$PREFIX/lib/clang/${MAJOR_VERSION}/include" not found"
+  exit 1
+fi
+# Make sure omp.h from conda environment is found by clang
+ln -sf $PREFIX/include/omp.h $PREFIX/lib/clang/${MAJOR_VERSION}/include/

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,7 +1,7 @@
 {% set version = "19.1.7" %}
 {% set major_version = version.split(".")[0] %}
 {% set tail_version = version.split(".")[-1] %}
-{% set build_number = 1 %}
+{% set build_number = 2 %}
 
 # always includes minor as of v18, see https://github.com/llvm/llvm-project/issues/76273
 {% set maj_min = major_version ~ "." ~ version.split(".")[1] %}


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
