### PR TITLE
Re-enable mingw C++ test

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -472,7 +472,7 @@ outputs:
     test:
       requires:
         - {{ compiler("cxx") }}
-        # - gxx_impl_{{ target_platform }}  # [win64]
+        - gxx_impl_{{ target_platform }}  # [win64]
       files:
         - mytest.cxx
       commands:
@@ -482,7 +482,7 @@ outputs:
         - unset CONDA_BUILD_SYSROOT   # [unix]
         - set "CONDA_BUILD_SYSROOT="  # [win]
         - clang++ -v -c mytest.cxx
-        # - clang++ -v mytest.cxx --target=x86_64-w64-mingw32  # [win64]
+        - clang++ -v mytest.cxx --target=x86_64-w64-mingw32  # [win64]
 
   - name: clang-format-{{ major_version }}
     script: install_clang_format.sh  # [unix]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -476,6 +476,8 @@ outputs:
       files:
         - mytest.cxx
       commands:
+        # avoid CMake picking up random clang in image when using unactivated compilers
+        - del /s /q "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\Llvm\x64\bin\clang++.exe"  # [win]
         - clang++ --version
         - clang++-{{ major_version }} --version
         - clang++ -v -c mytest.cxx


### PR DESCRIPTION
Descoped from #362, ran into
```
In file included from mytest.cxx:1:
In file included from %PREFIX%\Library\lib\gcc\x86_64-w64-mingw32\15.1.0\include\c++\iostream:43:
In file included from %PREFIX%\Library\lib\gcc\x86_64-w64-mingw32\15.1.0\include\c++\ostream:42:
In file included from %PREFIX%\Library\lib\gcc\x86_64-w64-mingw32\15.1.0\include\c++\bits/ostream.h:43:
In file included from %PREFIX%\Library\lib\gcc\x86_64-w64-mingw32\15.1.0\include\c++\ios:42:
In file included from %PREFIX%\Library\lib\gcc\x86_64-w64-mingw32\15.1.0\include\c++\iosfwd:44:
In file included from %PREFIX%\Library\lib\gcc\x86_64-w64-mingw32\15.1.0\include\c++\bits/postypes.h:42:
%PREFIX%\Library\lib\gcc\x86_64-w64-mingw32\15.1.0\include\c++\cwchar:49:10: fatal error: 'wchar.h' file not found
   49 | #include <wchar.h>
      |          ^~~~~~~~~
1 error generated.
```