### PR TITLE
[20.x] Rebuild for libxml2 2.14

### DIFF
--- a/.azure-pipelines/azure-pipelines-osx.yml
+++ b/.azure-pipelines/azure-pipelines-osx.yml
@@ -5,7 +5,7 @@
 jobs:
 - job: osx
   pool:
-    vmImage: macOS-13
+    vmImage: macOS-15
   strategy:
     matrix:
       osx_64_:

--- a/.ci_support/linux_64_.yaml
+++ b/.ci_support/linux_64_.yaml
@@ -16,10 +16,10 @@ docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:alma9
 libclang_soversion:
 - '13'
-libxml2:
-- '2.13'
+libxml2_devel:
+- '2.14'
 python_min:
-- '3.9'
+- '3.10'
 target_platform:
 - linux-64
 variant:

--- a/.ci_support/linux_aarch64_.yaml
+++ b/.ci_support/linux_aarch64_.yaml
@@ -16,10 +16,10 @@ docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:alma9
 libclang_soversion:
 - '13'
-libxml2:
-- '2.13'
+libxml2_devel:
+- '2.14'
 python_min:
-- '3.9'
+- '3.10'
 target_platform:
 - linux-aarch64
 variant:

--- a/.ci_support/linux_ppc64le_.yaml
+++ b/.ci_support/linux_ppc64le_.yaml
@@ -16,10 +16,10 @@ docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:alma9
 libclang_soversion:
 - '13'
-libxml2:
-- '2.13'
+libxml2_devel:
+- '2.14'
 python_min:
-- '3.9'
+- '3.10'
 target_platform:
 - linux-ppc64le
 variant:

--- a/.ci_support/migrations/libxml2214.yaml
+++ b/.ci_support/migrations/libxml2214.yaml
@@ -1,0 +1,10 @@
+__migrator:
+  build_number: 1
+  commit_message: Rebuild for libxml2 2.14
+  kind: version
+  migration_number: 1
+libxml2:
+- '2.14'
+libxml2_devel:
+- '2.14'
+migrator_ts: 1743812129.3751788

--- a/.ci_support/osx_64_.yaml
+++ b/.ci_support/osx_64_.yaml
@@ -16,12 +16,12 @@ cxx_compiler_version:
 - '19'
 libclang_soversion:
 - '13'
-libxml2:
-- '2.13'
+libxml2_devel:
+- '2.14'
 macos_machine:
 - x86_64-apple-darwin13.4.0
 python_min:
-- '3.9'
+- '3.10'
 target_platform:
 - osx-64
 variant:

--- a/.ci_support/osx_arm64_.yaml
+++ b/.ci_support/osx_arm64_.yaml
@@ -16,12 +16,12 @@ cxx_compiler_version:
 - '19'
 libclang_soversion:
 - '13'
-libxml2:
-- '2.13'
+libxml2_devel:
+- '2.14'
 macos_machine:
 - arm64-apple-darwin20.0.0
 python_min:
-- '3.9'
+- '3.10'
 target_platform:
 - osx-arm64
 variant:

--- a/.ci_support/win_64_.yaml
+++ b/.ci_support/win_64_.yaml
@@ -8,10 +8,10 @@ cxx_compiler:
 - vs2022
 libclang_soversion:
 - '13'
-libxml2:
-- '2.13'
+libxml2_devel:
+- '2.14'
 python_min:
-- '3.9'
+- '3.10'
 target_platform:
 - win-64
 variant:

--- a/.gitattributes
+++ b/.gitattributes
@@ -24,4 +24,5 @@ bld.bat text eol=crlf
 /README.md linguist-generated=true
 azure-pipelines.yml linguist-generated=true
 build-locally.py linguist-generated=true
+pixi.toml linguist-generated=true
 shippable.yml linguist-generated=true

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,7 +1,7 @@
 {% set version = "20.1.8" %}
 {% set major_version = version.split(".")[0] %}
 {% set tail_version = version.split(".")[-1] %}
-{% set build_number = 0 %}
+{% set build_number = 1 %}
 
 # always includes minor as of v18, see https://github.com/llvm/llvm-project/issues/76273
 {% set maj_min = major_version ~ "." ~ version.split(".")[1] %}
@@ -53,13 +53,13 @@ requirements:
     # "compiling .pyc files" fails without this
     - python >3
     - llvmdev {{ version }}     # [build_platform != target_platform]
-    - libxml2                   # [build_platform != target_platform]
+    - libxml2-devel             # [build_platform != target_platform]
     - zlib                      # [build_platform != target_platform]
     - zstd                      # [build_platform != target_platform]
   host:
     - libcxx-devel {{ cxx_compiler_version }}   # [osx]
     - llvmdev {{ version }}
-    - libxml2
+    - libxml2-devel
     - zlib
     - zstd
 
@@ -73,9 +73,9 @@ outputs:
       string: {{ variant }}_h{{ PKG_HASH }}_{{ build_number }}
       ignore_run_exports_from:
         # the build fails if it doesn't find the following, but it's not used
-        - zlib     # [unix]
-        - libxml2  # [unix]
-        - zstd     # [unix]
+        - libxml2-devel     # [unix]
+        - zlib              # [unix]
+        - zstd              # [unix]
     requirements:
       build:
         - {{ stdlib('c') }}
@@ -94,7 +94,7 @@ outputs:
         # because clangxx pins libcxx-devel to `maj_min`
         - libcxx-devel {{ maj_min }}    # [osx]
         - llvmdev {{ version }}
-        - libxml2
+        - libxml2-devel
         - zlib
         - zstd
       run:
@@ -148,9 +148,9 @@ outputs:
         - {{ pin_subpackage("libclang-cpp" ~ maj_min, max_pin="x.x") }}   # [unix]
       ignore_run_exports_from:
         # the build fails if it doesn't find the following, but it's not used
-        - zlib     # [unix]
-        - libxml2  # [unix]
-        - zstd     # [unix]
+        - libxml2-devel     # [unix]
+        - zlib              # [unix]
+        - zstd              # [unix]
     requirements:
       build:
         - {{ stdlib('c') }}
@@ -164,7 +164,7 @@ outputs:
         # Use the same requirements as the top-level requirements
         - libcxx-devel {{ cxx_compiler_version }}   # [osx]
         - llvmdev {{ version }}
-        - libxml2
+        - libxml2-devel
         - zlib
         - zstd
       run:
@@ -194,9 +194,9 @@ outputs:
         - {{ pin_subpackage("libclang-cpp" ~ maj_min, max_pin="x.x") }}   # [unix]
       ignore_run_exports_from:
         # the build fails if it doesn't find the following, but it's not used
-        - zlib     # [unix]
-        - libxml2  # [unix]
-        - zstd     # [unix]
+        - libxml2-devel     # [unix]
+        - zlib              # [unix]
+        - zstd              # [unix]
     requirements:
       build:
         - {{ stdlib('c') }}
@@ -211,7 +211,7 @@ outputs:
         # Use the same requirements as the top-level requirements
         - libcxx-devel {{ cxx_compiler_version }}   # [osx]
         - llvmdev {{ version }}
-        - libxml2
+        - libxml2-devel
         - zlib
         - zstd
       run:
@@ -244,7 +244,7 @@ outputs:
         - {{ pin_subpackage("libclang" ~ libclang_soversion, max_pin=None) }}
       ignore_run_exports_from:
         # the build fails if it doesn't find the following, but it's not used
-        - libxml2
+        - libxml2-devel
         - zlib     # [unix]
         - zstd     # [unix]
     requirements:
@@ -261,7 +261,7 @@ outputs:
         # Use the same requirements as the top-level requirements
         - libcxx-devel {{ cxx_compiler_version }}   # [osx]
         - llvmdev {{ version }}
-        - libxml2
+        - libxml2-devel
         - zlib
         - zstd
       run:
@@ -309,9 +309,9 @@ outputs:
         - {{ pin_subpackage("libclang" ~ libclang_soversion, max_pin=None) }}
       ignore_run_exports_from:
         # the build fails if it doesn't find the following, but it's not used
-        - zlib     # [unix]
-        - libxml2  # [unix]
-        - zstd     # [unix]
+        - libxml2-devel     # [unix]
+        - zlib              # [unix]
+        - zstd              # [unix]
     requirements:
       build:
         - {{ stdlib('c') }}
@@ -327,7 +327,7 @@ outputs:
         # Use the same requirements as the top-level requirements
         - libcxx-devel {{ cxx_compiler_version }}   # [osx]
         - llvmdev {{ version }}
-        - libxml2
+        - libxml2-devel
         - zlib
         - zstd
       run:
@@ -354,7 +354,7 @@ outputs:
       string: {{ variant }}_h{{ PKG_HASH }}_{{ build_number }}
       ignore_run_exports_from:
         # the build fails if it doesn't find the following, but it's not used
-        - libxml2
+        - libxml2-devel
         - zlib     # [unix]
         - zstd     # [unix]
     requirements:
@@ -371,7 +371,7 @@ outputs:
         # Use the same requirements as the top-level requirements
         - libcxx-devel {{ cxx_compiler_version }}   # [osx]
         - llvmdev {{ version }}
-        - libxml2
+        - libxml2-devel
         - zlib
         - zstd
       run:
@@ -412,7 +412,7 @@ outputs:
       string: {{ variant }}_h{{ PKG_HASH }}_{{ build_number }}
       ignore_run_exports_from:
         # the build fails if it doesn't find the following, but it's not used
-        - libxml2
+        - libxml2-devel
         - zlib     # [unix]
         - zstd     # [unix]
     requirements:
@@ -425,7 +425,7 @@ outputs:
         # Use the same requirements as the top-level requirements
         - libcxx-devel {{ cxx_compiler_version }}   # [osx]
         - llvmdev {{ version }}
-        - libxml2
+        - libxml2-devel
         - zlib
         - zstd
       run:
@@ -448,7 +448,7 @@ outputs:
       string: {{ variant }}_h{{ PKG_HASH }}_{{ build_number }}
       ignore_run_exports_from:
         # the build fails if it doesn't find the following, but it's not used
-        - libxml2
+        - libxml2-devel
         - zlib     # [unix]
         - zstd     # [unix]
     requirements:
@@ -461,7 +461,7 @@ outputs:
         # Use the same requirements as the top-level requirements
         - libcxx-devel {{ cxx_compiler_version }}   # [osx]
         - llvmdev {{ version }}
-        - libxml2
+        - libxml2-devel
         - zlib
         - zstd
       run:
@@ -498,9 +498,9 @@ outputs:
       skip: true  # [win]
       ignore_run_exports_from:
         # the build fails if it doesn't find the following, but it's not used
-        - zlib     # [unix]
-        - libxml2  # [unix]
-        - zstd     # [unix]
+        - libxml2-devel     # [unix]
+        - zlib              # [unix]
+        - zstd              # [unix]
     requirements:
       build:
         # "compiling .pyc files" fails without this
@@ -520,7 +520,7 @@ outputs:
         - libcxx-devel {{ maj_min }}    # [osx]
         - llvmdev {{ version }}
         - llvm {{ version }}
-        - libxml2
+        - libxml2-devel
         - zlib
         - zstd
       run:
@@ -545,7 +545,7 @@ outputs:
       string: {{ variant }}_h{{ PKG_HASH }}_{{ build_number }}
       ignore_run_exports_from:
         # the build fails if it doesn't find the following, but it's not used
-        - libxml2
+        - libxml2-devel
         - zlib
         - zstd
     requirements:
@@ -569,7 +569,7 @@ outputs:
         - libcxx-devel {{ maj_min }}    # [osx]
         - llvmdev {{ version }}
         - llvm {{ version }}
-        - libxml2
+        - libxml2-devel
         - zlib
         - zstd
       run:
@@ -615,7 +615,7 @@ outputs:
         - libcxx-devel {{ maj_min }}    # [osx]
         - llvmdev {{ version }}
         - llvm {{ version }}
-        - libxml2
+        - libxml2-devel
         - zlib
         - zstd
       run:


### PR DESCRIPTION
Bot seems to be waiting for phantom parents due to circular dependencies between xml2 and the compiler stack