### PR TITLE
[19.x] Move clang++-<maj> to clang-<maj> package

### DIFF
--- a/.ci_support/linux_64_.yaml
+++ b/.ci_support/linux_64_.yaml
@@ -2,8 +2,6 @@ c_stdlib:
 - sysroot
 c_stdlib_version:
 - '2.17'
-cdt_name:
-- conda
 channel_sources:
 - conda-forge
 channel_targets:

--- a/.ci_support/linux_aarch64_.yaml
+++ b/.ci_support/linux_aarch64_.yaml
@@ -2,8 +2,6 @@ c_stdlib:
 - sysroot
 c_stdlib_version:
 - '2.17'
-cdt_name:
-- conda
 channel_sources:
 - conda-forge
 channel_targets:

--- a/.ci_support/linux_ppc64le_.yaml
+++ b/.ci_support/linux_ppc64le_.yaml
@@ -2,8 +2,6 @@ c_stdlib:
 - sysroot
 c_stdlib_version:
 - '2.17'
-cdt_name:
-- conda
 channel_sources:
 - conda-forge
 channel_targets:

--- a/README.md
+++ b/README.md
@@ -165,12 +165,12 @@ it is possible to build and upload installable packages to the
 [conda-forge](https://anaconda.org/conda-forge) [anaconda.org](https://anaconda.org/)
 channel for Linux, Windows and OSX respectively.
 
-To manage the continuous integration and simplify feedstock maintenance
+To manage the continuous integration and simplify feedstock maintenance,
 [conda-smithy](https://github.com/conda-forge/conda-smithy) has been developed.
 Using the ``conda-forge.yml`` within this repository, it is possible to re-render all of
 this feedstock's supporting files (e.g. the CI configuration files) with ``conda smithy rerender``.
 
-For more information please check the [conda-forge documentation](https://conda-forge.org/docs/).
+For more information, please check the [conda-forge documentation](https://conda-forge.org/docs/).
 
 Terminology
 ===========
@@ -197,7 +197,7 @@ merged, the recipe will be re-built and uploaded automatically to the
 everybody to install and use from the `conda-forge` channel.
 Note that all branches in the conda-forge/clangdev-feedstock are
 immediately built and any created packages are uploaded, so PRs should be based
-on branches in forks and branches in the main repository should only be used to
+on branches in forks, and branches in the main repository should only be used to
 build distinct package versions.
 
 In order to produce a uniquely identifiable distribution:

--- a/recipe/install_clang.bat
+++ b/recipe/install_clang.bat
@@ -16,3 +16,8 @@ for /f "tokens=1 delims=." %%a in ("%PKG_VERSION%") do (
   move bin2\clang.exe bin\clang-%%a.exe
 )
 rmdir /s /q bin2
+
+cd %LIBRARY_BIN%
+for /f "tokens=1 delims=." %%a in ("%PKG_VERSION%") do (
+  copy clang-%%a.exe "clang++-%%a.exe"
+)

--- a/recipe/install_clang.sh
+++ b/recipe/install_clang.sh
@@ -11,3 +11,5 @@ if [[ ! -d $PREFIX/lib/clang/${MAJOR_VERSION}/include ]]; then
 fi
 # Make sure omp.h from conda environment is found by clang
 ln -sf $PREFIX/include/omp.h $PREFIX/lib/clang/${MAJOR_VERSION}/include/
+
+ln -s "${PREFIX}/bin/clang-${MAJOR_VERSION}" "${PREFIX}/bin/clang++-${MAJOR_VERSION}"

--- a/recipe/install_clangxx.bat
+++ b/recipe/install_clangxx.bat
@@ -4,5 +4,4 @@ cd %LIBRARY_BIN%
 setlocal enabledelayedexpansion
 for /f "tokens=1 delims=." %%a in ("%PKG_VERSION%") do (
   copy clang-%%a.exe "clang++.exe"
-  copy clang-%%a.exe "clang++-%%a.exe"
 )

--- a/recipe/install_clangxx.sh
+++ b/recipe/install_clangxx.sh
@@ -2,7 +2,4 @@
 
 set -ex
 
-maj_version="${PKG_VERSION%%.*}"
-
 ln -s $PREFIX/bin/clang  $PREFIX/bin/clang++
-ln -s "${PREFIX}/bin/clang-${maj_version}" "${PREFIX}/bin/clang++-${maj_version}"

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,7 +1,7 @@
 {% set version = "19.1.7" %}
 {% set major_version = version.split(".")[0] %}
 {% set tail_version = version.split(".")[-1] %}
-{% set build_number = 4 %}
+{% set build_number = 5 %}
 
 # always includes minor as of v18, see https://github.com/llvm/llvm-project/issues/76273
 {% set maj_min = major_version ~ "." ~ version.split(".")[1] %}
@@ -344,10 +344,12 @@ outputs:
     script: install_clang.sh  # [unix]
     script: install_clang.bat  # [win]
     files:
-      - lib/clang                                  # [unix]
-      - bin/clang-{{ major_version }}              # [unix]
-      - Library/lib/clang                          # [win]
-      - Library/bin/clang-{{ major_version }}.exe  # [win]
+      - lib/clang                                    # [unix]
+      - bin/clang-{{ major_version }}                # [unix]
+      - bin/clang++-{{ major_version }}              # [unix]
+      - Library/lib/clang                            # [win]
+      - Library/bin/clang-{{ major_version }}.exe    # [win]
+      - Library/bin/clang++-{{ major_version }}.exe  # [win]
     build:
       track_features:
         - root         # [variant and variant.startswith("root_")]
@@ -394,6 +396,7 @@ outputs:
 
         # versioned binaries
         - clang-{{ major_version }} --version
+        - clang++-{{ major_version }} --version
 
         # absence of unversioned binaries
         - test ! -f $PREFIX/bin/clang                   # [unix]


### PR DESCRIPTION
Backport https://github.com/conda-forge/clangdev-feedstock/pull/387