### PR TITLE
Address clobber warnings

### DIFF
--- a/recipe/install_clang.bat
+++ b/recipe/install_clang.bat
@@ -31,3 +31,12 @@ rmdir /s /q bin2
 
 cd %LIBRARY_BIN%
 copy clang-!MAJOR_VERSION!.exe "clang++-!MAJOR_VERSION!.exe"
+
+:: conda's use of `files:` disables usual before/after snapshotting mechanism
+:: of host environment, see https://github.com/conda/conda-build/issues/5455;
+:: since we're including `Library/lib/clang` on windows and llvm-openmp is in
+:: host, we need to delete files in that path which llvm-openmp brings along;
+:: only from 18-20 because those are the only versions where this is relevant
+rmdir /s /q %LIBRARY_LIB%\clang\18
+rmdir /s /q %LIBRARY_LIB%\clang\19
+rmdir /s /q %LIBRARY_LIB%\clang\20

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,7 +1,7 @@
 {% set version = "21.1.7" %}
 {% set major_version = version.split(".")[0] %}
 {% set tail_version = version.split(".")[-1] %}
-{% set build_number = 0 %}
+{% set build_number = 1 %}
 
 # always includes minor as of v18, see https://github.com/llvm/llvm-project/issues/76273
 {% set maj_min = major_version ~ "." ~ version.split(".")[1] %}


### PR DESCRIPTION
Address
```
ClobberWarning: This transaction has incompatible packages due to a shared path.
  packages: conda-forge/win-64::llvm-openmp-21.1.7-h4fa8253_0, local/win-64::clang-21-21.1.7-default_hac490eb_0
  path: 'library/lib/clang/18/include/omp.h'

ClobberWarning: This transaction has incompatible packages due to a shared path.
  packages: conda-forge/win-64::llvm-openmp-21.1.7-h4fa8253_0, local/win-64::clang-21-21.1.7-default_hac490eb_0
  path: 'library/lib/clang/19/include/omp.h'

ClobberWarning: This transaction has incompatible packages due to a shared path.
  packages: conda-forge/win-64::llvm-openmp-21.1.7-h4fa8253_0, local/win-64::clang-21-21.1.7-default_hac490eb_0
  path: 'library/lib/clang/20/include/omp.h'
```
which are ultimately due to (the same underlying issue as in) https://github.com/conda/conda-build/issues/5455