### PR TITLE
[20.x] don't pin down to build number for clangxx -> clangxx_impl_{...}

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,7 +1,7 @@
 {% set version = "20.1.8" %}
 {% set major_version = version.split(".")[0] %}
 {% set tail_version = version.split(".")[-1] %}
-{% set build_number = 8 %}
+{% set build_number = 9 %}
 
 # always includes minor as of v18, see https://github.com/llvm/llvm-project/issues/76273
 {% set maj_min = major_version ~ "." ~ version.split(".")[1] %}
@@ -518,7 +518,7 @@ outputs:
     build:
       track_features:
         - root         # [variant and variant.startswith("root_")]
-        - clang_nocfg  # [not with_cfg]
+        - clang_nocfg  # [unix and not with_cfg]
       string: {{ variant }}_cfg_h{{ PKG_HASH }}_{{ build_number }}    # [with_cfg]
       string: {{ variant }}_nocfg_h{{ PKG_HASH }}_{{ build_number }}  # [not with_cfg]
       ignore_run_exports_from:
@@ -592,7 +592,7 @@ outputs:
     build:
       track_features:
         - root         # [variant and variant.startswith("root_")]
-        - clang_nocfg  # [not with_cfg]
+        - clang_nocfg  # [unix and not with_cfg]
       string: {{ variant }}_cfg_h{{ PKG_HASH }}_{{ build_number }}    # [with_cfg]
       string: {{ variant }}_nocfg_h{{ PKG_HASH }}_{{ build_number }}  # [not with_cfg]
       ignore_run_exports_from:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -614,7 +614,12 @@ outputs:
         - zlib
         - zstd
       run:
-        - clangxx_impl_{{ target_platform }} {{ version }}.* {{ variant }}_*_{{ build_number }}   # [unix]
+        # we'd like to do the equivalent of pin_subpackage here (modulo cfg/nocfg); however,
+        # https://github.com/conda-forge/clang-compiler-activation-feedstock now depends on
+        # being able to co-install `clangxx_impl_{{ cross_target_platform }}` (built on that
+        # feedstock) with a `clangxx` from here (to have the symlinks available also for the
+        # bootstrap compilers), so we can't pin the build number either
+        - clangxx_impl_{{ target_platform }} {{ version }}.* {{ variant }}_*    # [unix]
         - {{ pin_subpackage("clang", exact=True) }}
         - libstdcxx-devel_{{ target_platform }}  # [linux]
         # only minor-pin to avoid issues when building new libcxx versions


### PR DESCRIPTION
After merging the compiler activation for v22, the [CI there](https://dev.azure.com/conda-forge/feedstock-builds/_build/results?buildId=1472730&view=results) got some new errors, but only for the native osx-64/osx-64 builds on clang 19 & 20.

```
Could not solve for environment specs
The following packages are incompatible
├─ clang-20 =20.1.8 default_hc369343_5 is requested and can be installed;
├─ clang_osx-64 =20.1.8 hfe02d3c_31 is requested and can be installed;
└─ clangxx_osx-64 =20.1.8 hfe02d3c_31 is not installable because it requires
   └─ clangxx_impl_osx-64 =20.1.8 * but there are no viable options
      ├─ clangxx_impl_osx-64 20.1.8 would require
      │  └─ clang-20 ==20.1.8 default_hd70426c_6, which conflicts with any installable versions previously reported;
      ├─ clangxx_impl_osx-64 20.1.8 would require
      │  └─ clang-20 ==20.1.8 default_hd70426c_7, which conflicts with any installable versions previously reported;
      ├─ clangxx_impl_osx-64 20.1.8 would require
      │  └─ clang-20 ==20.1.8 default_hd70426c_8, which conflicts with any installable versions previously reported;
      ├─ clangxx_impl_osx-64 20.1.8 would require
      │  └─ clang_osx-64 ==20.1.8 h7e5c614_25, which conflicts with any installable versions previously reported;
      ├─ clangxx_impl_osx-64 20.1.8 would require
      │  └─ clang_osx-64 ==20.1.8 h7e5c614_26, which conflicts with any installable versions previously reported;
      ├─ clangxx_impl_osx-64 20.1.8 would require
      │  └─ clang_osx-64 ==20.1.8 h7e5c614_27, which conflicts with any installable versions previously reported;
      ├─ clangxx_impl_osx-64 20.1.8 would require
      │  └─ clang_osx-64 ==20.1.8 h7e5c614_28, which conflicts with any installable versions previously reported;
      ├─ clangxx_impl_osx-64 20.1.8 would require
      │  └─ clang-20 ==20.1.8 root_63800_hfc45171_6, which conflicts with any installable versions previously reported;
      ├─ clangxx_impl_osx-64 20.1.8 would require
      │  └─ clang-20 ==20.1.8 root_63800_hfc45171_7, which conflicts with any installable versions previously reported;
      └─ clangxx_impl_osx-64 20.1.8 would require
         └─ clang-20 ==20.1.8 root_63800_hfc45171_8, which conflicts with any installable versions previously reported.
```
Partially this is due to moving `clang{,xx}_impl_{{ target_platform }}` to this feedstock, but the problem is (I think) obfuscated by the solver, not least because none of the (native) outputs on the activation feedstock explicitly depend on `clang-20`.

The failure is happening for the bootrap compilers
```
Packaging clang_bootstrap_osx-64
Reloading output folder: ...working... done
Solving environment (_h_env): ...working... failed
```
which [depends](https://github.com/conda-forge/clang-compiler-activation-feedstock/blob/8033380d885f7bbe318236086d49a38f0b2185b4/recipe/meta.yaml#L136) on `clangxx`, presumably for the bare symlinks. This is (I believe) ultimately the reason why the solver gets forced to pick `clang-20 =20.1.8 default_hc369343_5`, because all the builds after #415 pin `clangxx_impl` too tightly in `clangxx`. I think this was at least partially due to reviews from me, so apologies for that. 

AFAICT we can either loosen the pin here (as in this PR), or remove `clangxx` from the bootstrap compilers. Your opinion would be appreciated @isuruf, otherwise I'll try this PR and see if it fixes things (since v20 is not the default compiler anywhere, the risk is minimal).

Also backport fce834dfeb9f198e70162005bf0dbaee32c8ce4e while we're touching the branch.