### PR TITLE
[20.x] Backport llvm-buildstring for ld64, move bare `bin/ld` symlink on osx to `clang`

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -549,6 +549,7 @@ outputs:
         - clang-{{ major_version }} {{ version }}.* {{ variant }}_*             # [osx]
         - {{ pin_subpackage("clang-" ~ major_version, exact=True) }}            # [not osx]
         - {{ pin_subpackage("clang_impl_" ~ target_platform, exact=True) }}     # [unix]
+        - ld64_{{ target_platform }} * llvm{{ maj_min.replace(".", "_") }}_*    # [osx]
     test:
       commands:
         - clang --version

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,7 +1,7 @@
 {% set version = "20.1.8" %}
 {% set major_version = version.split(".")[0] %}
 {% set tail_version = version.split(".")[-1] %}
-{% set build_number = 11 %}
+{% set build_number = 12 %}
 
 # always includes minor as of v18, see https://github.com/llvm/llvm-project/issues/76273
 {% set maj_min = major_version ~ "." ~ version.split(".")[1] %}
@@ -500,7 +500,6 @@ outputs:
         - llvm-tools {{ version }}.*           # [osx]
         - cctools_impl_{{ target_platform }}   # [osx]
         - ld64_{{ target_platform }} * llvm{{ maj_min.replace(".", "_") }}_*    # [osx]
-        - ld64                                 # [osx]
         - llvm-openmp >={{ version }}
     test:
       commands:
@@ -550,6 +549,8 @@ outputs:
         - {{ pin_subpackage("clang-" ~ major_version, exact=True) }}            # [not osx]
         - {{ pin_subpackage("clang_impl_" ~ target_platform, exact=True) }}     # [unix]
         - ld64_{{ target_platform }} * llvm{{ maj_min.replace(".", "_") }}_*    # [osx]
+        - ld64                                 # [osx]
+        - cctools                              # [osx]
     test:
       commands:
         - clang --version


### PR DESCRIPTION
Despite #437 and follow-up commits (https://github.com/conda-forge/clangdev-feedstock/commit/3049916a42d5fdca47be0f486ac053c48079a55f), https://github.com/conda-forge/clang-compiler-activation-feedstock/pull/188 still runs into almost certainly spurious solver errors. I noticed that we were missing the pin on the llvm build string in `clang` (c.f. fe579838374a821a0b5efaa17c7ca91202800f38). That, as well as the fact that the bare `ld64`
https://github.com/conda-forge/clangdev-feedstock/blob/3049916a42d5fdca47be0f486ac053c48079a55f/recipe/meta.yaml#L502-L503
seems to really eff up the solver

<details>

```bash
Encountered problems while solving:
  - nothing provides ld64_osx-64 955.13 h21bdf93_3 needed by ld64-955.13-h2b71b23_3
                                 ^^^^^^
                                 # NO PACKAGE DEPENDS ON THIS VERSION

Could not solve for environment specs
The following packages are incompatible
├─ cctools_impl_osx-64 =1030.6.3 llvm20_1_h1460d39_4 is installable and it requires
│  └─ ld64 =956.6 *, which can be installed;
├─ clang-20 =20.1.8 default_hc369343_5 is requested and can be installed;
├─ clang =20.1.8 default_h1323312_5 is requested and can be installed;
├─ clang_osx-64 =20.1.8 hfe02d3c_32 is requested and can be installed;
├─ clangxx_osx-64 =20.1.8 hfe02d3c_32 is installable and it requires
│  └─ clangxx_impl_osx-64 =20.1.8 * with the potential options
│     ├─ clangxx_impl_osx-64 20.1.8 would require
│     │  └─ clang-20 ==20.1.8 default_hd70426c_10, which conflicts with any installable versions previously reported;
│     ├─ clangxx_impl_osx-64 20.1.8 would require
│     │  └─ clang_impl_osx-64 [==20.1.8 default_cfg_h91eacd1_11|==20.1.8 default_nocfg_h66bedba_11], which requires
│     │     └─ ld64 =* * with the potential options
│     │        ├─ ld64 [274.2|409.12|...|955.13] conflicts with any installable versions previously reported;
│     │        ├─ ld64 955.13 would require
│     │        │  └─ ld64_osx-64 ==955.13 h21bdf93_3, which does not exist (perhaps a missing channel);
│     │        ├─ ld64 955.13 would require
│     │        │  └─ ld64_osx-64 ==955.13 h2cc85ee_3, which does not exist (perhaps a missing channel);
│     │        ├─ ld64 955.13 would require
│     │        │  └─ ld64_osx-64 ==955.13 h466f870_3, which does not exist (perhaps a missing channel);
│     │        ├─ ld64 956.6 would require
│     │        │  └─ ld64_osx-64 ==956.6 llvm20_1_h21bdf93_0, which can be installed;
│     │        ├─ ld64 956.6 would require
│     │        │  └─ ld64_osx-64 [==956.6 llvm21_1_h2cc85ee_0|==956.6 llvm21_1_h2cc85ee_1|==956.6 llvm21_1_h2cc85ee_2|==956.6 llvm21_1_h2cc85ee_3|==956.6 llvm21_1_h41cbea9_4], which requires
│     │        │     └─ clang =21.1 *, which conflicts with any installable versions previously reported;
│     │        ├─ ld64 956.6 would require
│     │        │  └─ ld64_osx-64 [==956.6 llvm19_1_h466f870_0|==956.6 llvm19_1_h466f870_1|==956.6 llvm19_1_h466f870_2|==956.6 llvm19_1_h466f870_3|==956.6 llvm19_1_hcae3351_4], which requires
│     │        │     └─ clang =19.1 *, which conflicts with any installable versions previously reported;
│     │        ├─ ld64 956.6 would require
│     │        │  └─ ld64_osx-64 ==956.6 llvm20_1_h21bdf93_1, which can be installed;
│     │        ├─ ld64 956.6 would require
│     │        │  └─ ld64_osx-64 ==956.6 llvm20_1_h21bdf93_2, which can be installed;
│     │        ├─ ld64 956.6 would require
│     │        │  └─ ld64_osx-64 ==956.6 llvm20_1_h21bdf93_3, which can be installed;
│     │        ├─ ld64 956.6 would require
│     │        │  └─ ld64_osx-64 ==956.6 llvm20_1_hb7237e5_4, which can be installed;    # THIS WOULD BE THE SOLUTION!
│     │        └─ ld64 956.6 would require
│     │           └─ ld64_osx-64 ==956.6 llvm22_1_h163eae7_4, which requires
│     │              └─ clang =22.1 *, which conflicts with any installable versions previously reported;
│     ├─ [...]
│     └─ clangxx_impl_osx-64 20.1.8 would require
│        └─ clang-20 ==20.1.8 root_63800_hfc45171_9, which conflicts with any installable versions previously reported;
└─ ld64_osx-64 =956.6 llvm20_1_h09aa6f7_4 is not installable because it conflicts with any installable versions previously reported.

```

</details>

Since `ld64` only [adds](https://conda-metadata-app.streamlit.app/?q=conda-forge%2Fosx-64%2Fld64-956.6-llvm20_1_h2b71b23_4.conda) `bin/ld` on top of `ld64_<tgt>`, also move this to `clang`, where it is more appropriate (together with all the other bare symlinks). Also add `cctools`, which matches the state of dependencies for `clang` in ongoing PRs.