### PR TITLE
[20.x] add root track_features for clang-no-conda-cfg; build python-clang only for default

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,7 +1,7 @@
 {% set version = "20.1.8" %}
 {% set major_version = version.split(".")[0] %}
 {% set tail_version = version.split(".")[-1] %}
-{% set build_number = 13 %}
+{% set build_number = 14 %}
 
 # always includes minor as of v18, see https://github.com/llvm/llvm-project/issues/76273
 {% set maj_min = major_version ~ "." ~ version.split(".")[1] %}
@@ -562,6 +562,8 @@ outputs:
     build:
       skip: true  # [with_cfg]
       string: {{ variant }}_h{{ PKG_HASH }}_{{ build_number }}
+      track_features:
+        - root         # [variant and variant.startswith("root_")]
     requirements:
       run:
         - clang {{ version }} {{ variant }}_nocfg_*_{{ build_number }}
@@ -818,8 +820,8 @@ outputs:
       noarch: python
       # Building this output using this recipe is only supported on unix
       # It can still be installed on Windows as it is marked as `noarch: python`
-      skip: true  # [not linux64]
-      string: {{ variant }}_h{{ PKG_HASH }}_{{ build_number }}
+      skip: true  # [not (linux64 and variant == "default")]
+      string: h{{ PKG_HASH }}_{{ build_number }}
     script: build_python_bindings.sh
     requirements:
       host:


### PR DESCRIPTION
This leads weird situations like installing
```
 │ │ │ clang                         ┆ 20.1.8       ┆ root_63800_nocfg_h2c50e62_13 ┆ conda-forge ┆   69.14 KiB │
 │ │ │ clang-20                      ┆ 20.1.8       ┆ root_63800_h608ee54_13       ┆ conda-forge ┆   55.99 MiB │
 │ │ │ clang-no-conda-cfg            ┆ 20.1.8       ┆ root_63800_h4f968ed_13       ┆ conda-forge ┆   68.43 KiB │
 │ │ │ clang_impl_linux-64           ┆ 20.1.8       ┆ root_63800_nocfg_h36841f4_13 ┆ conda-forge ┆   69.02 KiB │
 │ │ │ clang_linux-64                ┆ 20.1         ┆ h3ee2658_21                  ┆ conda-forge ┆   28.30 KiB │
 │ │ │ clangxx_impl_linux-64         ┆ 20.1.8       ┆ root_63800_nocfg_h36841f4_13 ┆ conda-forge ┆   68.96 KiB │
 │ │ │ clangxx_linux-64              ┆ 20.1         ┆ hcbb976a_21                  ┆ conda-forge ┆   26.87 KiB │
 ```
 even though nothing root-related has been requested; c.f. [here](https://github.com/conda-forge/jaxlib-feedstock/pull/336#discussion_r2906023512)
 
 While we're at it, `python-clang` does not do any variant pinning, so we only need to build it once.