### PR TITLE
Fix name of ppc64le conda triplet

### DIFF
--- a/recipe/install_clang_cfg.sh
+++ b/recipe/install_clang_cfg.sh
@@ -1,5 +1,7 @@
 if [[ "${target_platform}" == "linux-64" ]]; then
   TARGET=x86_64-conda-linux-gnu
+elif [[ "${target_platform}" == "linux-ppc64le" ]]; then
+  TARGET=powerpc64le-conda-linux-gnu
 elif [[ "${target_platform}" == "linux-"* ]]; then
   TARGET=${target_platform/linux-/}-conda-linux-gnu
 elif [[ "${target_platform}" == "osx-64" ]]; then

--- a/recipe/install_clang_symlinks.sh
+++ b/recipe/install_clang_symlinks.sh
@@ -3,6 +3,8 @@ set -ex
 
 if [[ "${target_platform}" == "linux-64" ]]; then
   TARGET=x86_64-conda-linux-gnu
+elif [[ "${target_platform}" == "linux-ppc64le" ]]; then
+  TARGET=powerpc64le-conda-linux-gnu
 elif [[ "${target_platform}" == "linux-"* ]]; then
   TARGET=${target_platform/linux-/}-conda-linux-gnu
 elif [[ "${target_platform}" == "osx-64" ]]; then

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,7 +1,7 @@
 {% set version = "22.1.3" %}
 {% set major_version = version.split(".")[0] %}
 {% set tail_version = version.split(".")[-1] %}
-{% set build_number = 0 %}
+{% set build_number = 1 %}
 
 # always includes minor as of v18, see https://github.com/llvm/llvm-project/issues/76273
 {% set maj_min = major_version ~ "." ~ version.split(".")[1] %}
@@ -435,6 +435,8 @@ outputs:
       commands:
         - x86_64-conda-linux-gnu-clang --version         # [linux64]
         - x86_64-conda-linux-gnu-clang-cpp --version     # [linux64]
+        - powerpc64le-conda-linux-gnu-clang --version    # [linux and ppc64le]
+        - powerpc64le-conda-linux-gnu-clang-cpp --version  # [linux and ppc64le]
         - x86_64-apple-darwin13.4.0-clang --version      # [osx and x86_64]
         - x86_64-apple-darwin13.4.0-clang-cpp --version  # [osx and x86_64]
 
@@ -508,6 +510,7 @@ outputs:
     test:
       commands:
         - x86_64-conda-linux-gnu-clang++ --version         # [linux64]
+        - powerpc64le-conda-linux-gnu-clang++ --version    # [linux and ppc64le]
         - x86_64-apple-darwin13.4.0-clang++ --version      # [osx and x86_64]
 
   - name: clangxx


### PR DESCRIPTION
Fix https://github.com/conda-forge/clangdev-feedstock/issues/446 .

https://github.com/conda-forge/clangdev-feedstock/pull/405 implicitly assumed that the triplet for `linux-ppc64le` was `ppc64le-conda-linux-gnu`, while the one used in other feedstock is  `powerpc64le-conda-linux-gnu`.

Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
