### PR TITLE
Remove circular symlink

### DIFF
--- a/recipe/install_clang_tools.sh
+++ b/recipe/install_clang_tools.sh
@@ -5,35 +5,33 @@ cd ${SRC_DIR}/clang/build
 make install
 cd $PREFIX
 
+MAJOR_VERSION=$(echo ${PKG_VERSION} | cut -f1 -d".")
+
 # Remove stuff that should be in clangdev
 rm -rf include/clang
 rm -rf include/clang-c
 rm -rf include/clang-tidy
 rm -rf lib/cmake/clang/
 rm -rf lib/lib*.a
+# part of output "clang", not "clang-tools"
+rm ${PREFIX}/bin/clang
+rm ${PREFIX}/bin/clang-${MAJOR_VERSION}
+rm ${PREFIX}/bin/clang-cpp
+rm ${PREFIX}/bin/clang-cl
+# part of output "clang-format", not "clang-tools"
+rm ${PREFIX}/bin/clang-format-*
+# part of output "clang-scan-deps", not "clang-tools"
+rm ${PREFIX}/bin/clang-scan-deps-*
+# already a symlink to $PREFIX/bin/llvm-offload-binary
+rm ${PREFIX}/bin/clang-offload-packager-*
 
-MAJOR_VERSION=$(echo ${PKG_VERSION} | cut -f1 -d".")
 for f in ${PREFIX}/bin/clang-*; do
-    if [[ "$(basename $f)" == clang-format-* ]]; then
-        # already got versioned in install_clang_format.sh
-        continue
-    elif [[ "$(basename $f)" == clang-offload-packager-* ]]; then
-        # links to llvm-offload-binary
-        continue
-    elif [[ "$(basename $f)" == "clang-${MAJOR_VERSION}" ]]; then
-        # installation also creates a versioned clang, no need to re-version it
+    if [[ "$(basename $f)" == "*-${MAJOR_VERSION}" ]]; then
+        # installation already creates multiple versioned binaries, no need to re-version them
         continue
     fi
+    # add version to actual binary and make $PREFIX/bin/clang-foo a symlink to it
     rm -f ${PREFIX}/bin/$(basename $f)-${MAJOR_VERSION}
     mv $f ${PREFIX}/bin/$(basename $f)-${MAJOR_VERSION};
     ln -s ${PREFIX}/bin/$(basename $f)-${MAJOR_VERSION} $f;
 done
-
-# part of output "clang", not "clang-tools"
-rm ${PREFIX}/bin/clang-${MAJOR_VERSION}
-rm ${PREFIX}/bin/clang-cpp-${MAJOR_VERSION}
-rm ${PREFIX}/bin/clang-cl-${MAJOR_VERSION}
-
-# part of output "clang-scan-deps", not "clang-tools"
-rm -f ${PREFIX}/bin/clang-scan-deps
-rm -f ${PREFIX}/bin/clang-scan-deps-${MAJOR_VERSION}

--- a/recipe/install_clang_tools.sh
+++ b/recipe/install_clang_tools.sh
@@ -17,6 +17,9 @@ for f in ${PREFIX}/bin/clang-*; do
     if [[ "$(basename $f)" == clang-format-* ]]; then
         # already got versioned in install_clang_format.sh
         continue
+    elif [[ "$(basename $f)" == clang-offload-packager-* ]]; then
+        # links to llvm-offload-binary
+        continue
     elif [[ "$(basename $f)" == "clang-${MAJOR_VERSION}" ]]; then
         # installation also creates a versioned clang, no need to re-version it
         continue

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -773,6 +773,8 @@ outputs:
       commands:
         - clang-check --version
         - clang-tidy --version
+        # absence of "doubly versioned" binaries
+        - test -z "$(find "${PREFIX}/bin" -name '*-{{ major_version }}-{{ major_version }}' -print)"    # [unix]
 
   - name: python-clang
     build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,7 +1,7 @@
 {% set version = "22.1.7" %}
 {% set major_version = version.split(".")[0] %}
 {% set tail_version = version.split(".")[-1] %}
-{% set build_number = 0 %}
+{% set build_number = 1 %}
 
 # always includes minor as of v18, see https://github.com/llvm/llvm-project/issues/76273
 {% set maj_min = major_version ~ "." ~ version.split(".")[1] %}


### PR DESCRIPTION
clang-offload-packager-22 is already a symlink to llvm-tools. Skip it to avoid creating a symlink to itself.

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
