### PR TITLE
Add git-clang-format to clang-format package

### DIFF
--- a/recipe/install_clang_format.sh
+++ b/recipe/install_clang_format.sh
@@ -10,3 +10,9 @@ mv ${PREFIX}/bin/clang-format ${PREFIX}/bin/clang-format-${MAJOR_VERSION}
 if [[ "$PKG_NAME" == "clang-format" ]]; then
   ln -sf $PREFIX/bin/clang-format-${MAJOR_VERSION} $PREFIX/bin/clang-format
 fi
+
+# Install git-clang-format
+if [[ "$PKG_NAME" == "clang-format" ]]; then
+  cp ${SRC_DIR}/clang/tools/clang-format/git-clang-format ${PREFIX}/bin/
+  chmod +x ${PREFIX}/bin/git-clang-format
+fi

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -857,7 +857,9 @@ outputs:
         file: install_clang_format
       files:
         - if: unix
-          then: bin/clang-format
+          then:
+            - bin/clang-format
+            - bin/git-clang-format
           else: Library/bin/clang-format.exe
       variant:
         down_prioritize_variant: ${{ 0 if variant == "default" else 1 }}


### PR DESCRIPTION
Include `git-clang-format` script from LLVM source tree into the `clang-format` conda package.\n\n- Copies `clang/tools/clang-format/git-clang-format` to `$PREFIX/bin/` during install\n- Added to the `files` list of the `clang-format` output (unix only)

https://github.com/llvm/llvm-project/blob/main/clang/tools/clang-format/git-clang-format